### PR TITLE
#47 - Fix failing yaml - update v1

### DIFF
--- a/.github/workflows/update-v1-tag.yml
+++ b/.github/workflows/update-v1-tag.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   update-v1:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-v1-tag.yml
+++ b/.github/workflows/update-v1-tag.yml
@@ -4,11 +4,10 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-
 jobs:
   update-v1:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Release Notes:
- Updated workflow permissions to allow automated updates to the "v1" tag during release publication.

Closes #47 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to allow automated updates to the "v1" tag during release publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->