### PR TITLE
Feature/78 add 3rd type of coverage threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,26 +54,27 @@ jobs:
 
 ### Action Inputs
 
-| Name                         | Description                                                                                                                                                                                                              | Required                      | Default                                                                                                   | 
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `paths`                      | Comma-separated paths to the generated Jacoco XML files. Supports wildcard glob patterns.                                                                                                                                | **Yes**                       |                                                                                                           |
-| `exclude-paths`              | Comma-separated paths to exclude from coverage analysis. Supports glob patterns.                                                                                                                                         | No                            | ''                                                                                                        |
-| `min-coverage-overall`       | Minimum overall code coverage percentage required to pass the check.                                                                                                                                                     | No                            | 0                                                                                                         |
-| `min-coverage-changed-files` | Minimum code coverage percentage required for changed files.                                                                                                                                                             | No                            | 0                                                                                                         |
-| `title`                      | Title for the coverage report comment added to the Pull Request.                                                                                                                                              | No                            | single: `JaCoCo Coverage Report` <br> multi: `Report: {report name}` <br> module: `Module: {module name}` |
-| `pr-number`                  | Number of the pull request. If not provided, the action will attempt to determine <br> the PR number from the GitHub context.                                                                                            | No                            | ''                                                                                                        |
-| `metric`                     | A metric to use for coverage calculation (`instruction`, `line`, `branch`, `complexity`, `method`, `class`).                                                                                                             | No                            | `instruction`                                                                                             | 
-| `sensitivity`                | Control the sensitivity of the coverage evaluation to the thresholds (`minimal,` `summary,` or `detail`).                                                                                                                | No                            | `detailed`                                                                                                | 
-| `comment-mode`               | Mode of the comment (`single` for one comment, `multi` for comments per jacoco.xml file, <br> `module` for comment per each module).                                                                                     | No                            | `single`                                                                                                  |
-| `modules`                    | List of modules and their unique paths (e.g., `management: context/management`).<br>Required when `comment-mode` set to `module`. <br> Optional when `comment-mode` set to `single`.                                     | If `comment-mode` is `module` | ``                                                                                                        |
-| `modules-thresholds`         | List of modules and their coverage thresholds (e.g., `core: 80`). Optional when `comment-mode` set to `module`.                                                                                                          | No                            | ``                                                                                                        |
-| `skip-not-changed`           | If enabled (true), filters JaCoCo-related comments to show only relevant changes.<br>It removes unchanged lines from the modules table and skips comments for unmodified modules and reports, <br> reducing noise in PRs. | No                            | false                                                                                                     |
-| `baseline-paths`             | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.<br>Paths have to be valid for modules if used.                                                                                       | No                            | ''                                                                                                        |
-| `update-comment`             | If enabled (true), ensures the action updates an existing comment with the latest coverage <br> data instead of creating a new comment. Prevents comment clutter in pull requests.                                       | No                            | true                                                                                                      |
-| `pass-symbol`                | Symbol displayed next to passing checks in the pull request comments (e.g., ✅, **Passed**).                                                                                                                              | No                            | ✅                                                                                                         |
-| `fail-symbol`                | Symbol displayed next to failing checks in the pull request comments (e.g., ❌, **Failed**).                                                                                                                              | No                            | ❌                                                                                                         |
-| `fail-on-threshold`          | If enabled (true), fails the GitHub action if a threshold is not reached.                                                                                                                                                | No                            | true                                                                                                      |
-| `debug`                      | Enables detail logging for debugging purposes. Automatically activated if the GitHub <br> workflow is run in debug mode (ACTIONS_RUNNER_DEBUG=true).                                                                     | No                            | false                                                                                                     |
+| Name                            | Description                                                                                                                                                                                                             | Required                        | Default                                                                                                   | 
+|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `paths`                         | Comma-separated paths to the generated Jacoco XML files. Supports wildcard glob patterns.                                                                                                                               | **Yes**                         |                                                                                                           |
+| `exclude-paths`                 | Comma-separated paths to exclude from coverage analysis. Supports glob patterns.                                                                                                                                        | No                              | ''                                                                                                        |
+| `min-coverage-overall`          | Minimum **overall code coverage** percentage required to pass the check.                                                                                                                                                | No                              | 0                                                                                                         |
+| `min-coverage-changed-files`    | Minimum **average code coverage** required across changed files, depending on the selected `comment-mode`.                                                                                                              | No                              | 0                                                                                                         |
+| `min-coverage-per-changed-file` | Minimum **code coverage** percentage required for each changed file **individually**.                                                                                                                                       | No                              | 0                                                                                                         |
+| `title`                         | Title for the coverage report comment added to the Pull Request.                                                                                                                                                        | No                              | single: `JaCoCo Coverage Report` <br> multi: `Report: {report name}` <br> module: `Module: {module name}` |
+| `pr-number`                     | Number of the pull request. If not provided, the action will attempt to determine <br> the PR number from the GitHub context.                                                                                           | No                              | ''                                                                                                        |
+| `metric`                        | A metric to use for coverage calculation (`instruction`, `line`, `branch`, `complexity`, `method`, `class`).                                                                                                            | No                              | `instruction`                                                                                             | 
+| `sensitivity`                   | Control the sensitivity of the coverage evaluation to the thresholds (`minimal,` `summary,` or `detail`).                                                                                                               | No                              | `detailed`                                                                                                | 
+| `comment-mode`                  | Mode of the comment (`single` for one comment, `multi` for comments per jacoco.xml file, <br> `module` for comment per each module).                                                                                    | No                              | `single`                                                                                                  |
+| `modules`                       | List of modules and their unique paths (e.g., `management: context/management`).<br>Required when `comment-mode` set to `module`. <br> Optional when `comment-mode` set to `single`.                                    | If `comment-mode` is `module`   | ``                                                                                                        |
+| `modules-thresholds`            | List of modules and their coverage thresholds (e.g., `core: 80`). Optional when `comment-mode` set to `module`.                                                                                                         | No                              | ``                                                                                                        |
+| `skip-not-changed`              | If enabled (true), filters JaCoCo-related comments to show only relevant changes.<br>It removes unchanged lines from the modules table and skips comments for unmodified modules and reports, <br> reducing noise in PRs. | No                              | false                                                                                                     |
+| `baseline-paths`                | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.<br>Paths have to be valid for modules if used.                                                                                      | No                              | ''                                                                                                        |
+| `update-comment`                | If enabled (true), ensures the action updates an existing comment with the latest coverage <br> data instead of creating a new comment. Prevents comment clutter in pull requests.                                      | No                              | true                                                                                                      |
+| `pass-symbol`                   | Symbol displayed next to passing checks in the pull request comments (e.g., ✅, **Passed**).                                                                                                                             | No                              | ✅                                                                                                         |
+| `fail-symbol`                   | Symbol displayed next to failing checks in the pull request comments (e.g., ❌, **Failed**).                                                                                                                             | No                              | ❌                                                                                                         |
+| `fail-on-threshold`             | If enabled (true), fails the GitHub action if a threshold is not reached.                                                                                                                                               | No                              | true                                                                                                      |
+| `debug`                         | Enables detail logging for debugging purposes. Automatically activated if the GitHub <br> workflow is run in debug mode (ACTIONS_RUNNER_DEBUG=true).                                                                    | No                              | false                                                                                                     |
 
 > Hint: default values have been defined to provide maximal possible information in the comment.
 
@@ -131,7 +132,15 @@ The `exclude-paths` input allows you to specify files or directories that should
 
 #### Customizing the Global Coverage Thresholds
 
-The `min-coverage-overall` and `min-coverage-changed-files` inputs allow you to set global coverage thresholds for the overall code coverage and changed files.
+You can use these inputs to define minimum required code coverage levels for your pull requests:
+- `min-coverage-overall`: Minimum coverage required across **all files** in the project.
+- `min-coverage-changed-files`: Minimum **average coverage** required across changed files. The exact set of files depends on the selected **change scope mode**:
+  - `single`: All changed files in the pull request.
+  - `multi`: All changed files in each report.
+  - `module`: All changed files in each module.
+- `min-coverage-per-changed-file`: Minimum coverage required for each individual changed file. If any file falls below this value, the check will fail.
+
+These thresholds help you maintain consistent test quality as your codebase evolves.
 
 ```yaml
 - name: Publish JaCoCo Report
@@ -141,6 +150,7 @@ The `min-coverage-overall` and `min-coverage-changed-files` inputs allow you to 
     paths: **/jacoco/**/*.xml
     min-coverage-overall: 80  # Require at least 80% overall coverage
     min-coverage-changed-files: 70  # Require at least 70% coverage for changed files
+    min-coverage-per-changed-file: 60  # Require at least 60% coverage for each changed file
     fail-on-threshold: true  # Fail the GitHub action if a threshold is not reached
  ```
 
@@ -200,18 +210,18 @@ The `modules-thresholds` input allows you to set custom coverage thresholds for 
   with:
     token: '${{ secrets.TOKEN }}'
     paths: **/jacoco/**/*.xml
-    sensitivity: 'minimal'  # Select a minimal sensitivity of the coverage report
-    comment-mode: 'single'  # Add a single comment for the all reports
+    sensitivity: 'minimal'      # Select a minimal sensitivity of the coverage report
+    comment-mode: 'single'      # Add a single comment for the all reports
     modules: |
       core: core
       module-a: context/module_a
       module-b: module_b
       utils: utils
     modules-thresholds: |
-      core:80.5*             # Custom threshold for core module only for overall
-      utils:*70.0            # Custom threshold for utils module only for changed files
-      module-a:80.0*70.0     # Custom thresholds for common module for overall and changed files
-      module c:80.0*70.0     # Custom thresholds for common module for overall and changed files
+      core:80.5**                # Custom threshold for core module only for overall
+      utils:*70.0*               # Custom threshold for utils module only for changed files
+      module-a:80.0*70.0*        # Custom thresholds for common module for overall and changed files
+      module c:80.0*70.0*25.0    # Custom thresholds for common module for overall, changed files and per changed file
 ```    
 
 ##### Minimal Sensitivity

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Minimum coverage percentage for changed files.'
     required: false
     default: '0.0'
+  min-coverage-per-changed-file:
+    description: 'Minimum coverage percentage for each changed file.'
+    required: false
+    default: '0.0'
   title:
     description: 'Title of the PR comment.'
     required: false
@@ -142,6 +146,7 @@ runs:
 
         echo "INPUT_MIN_COVERAGE_OVERALL=${{ inputs.min-coverage-overall }}" >> $GITHUB_ENV
         echo "INPUT_MIN_COVERAGE_CHANGED_FILES=${{ inputs.min-coverage-changed-files }}" >> $GITHUB_ENV
+        echo "INPUT_MIN_COVERAGE_PER_CHANGED_FILE=${{ inputs.min-coverage-per-changed-file }}" >> $GITHUB_ENV
         echo "INPUT_TITLE=${{ inputs.title }}" >> $GITHUB_ENV
         echo "INPUT_PR_NUMBER=${{ inputs.pr-number }}" >> $GITHUB_ENV
         echo "INPUT_METRIC=${{ inputs.metric }}" >> $GITHUB_ENV
@@ -176,6 +181,7 @@ runs:
         INPUT_EXCLUDE_PATHS: ${{ env.INPUT_EXCLUDE_PATHS }}
         INPUT_MIN_COVERAGE_OVERALL: ${{ env.INPUT_MIN_COVERAGE_OVERALL }}
         INPUT_MIN_COVERAGE_CHANGED_FILES: ${{ env.INPUT_MIN_COVERAGE_CHANGED_FILES }}
+        INPUT_MIN_COVERAGE_PER_CHANGED_FILE: ${{ env.INPUT_MIN_COVERAGE_PER_CHANGED_FILE }}
         INPUT_TITLE: ${{ env.INPUT_TITLE }}
         INPUT_PR_NUMBER: ${{ env.INPUT_PR_NUMBER }}
         INPUT_METRIC: ${{ env.INPUT_METRIC }}

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -366,6 +366,7 @@ class ActionInputs:
         # Overall
         values = module_threshold_parts[1].split("*")
         if len(values[0]) == 0:
+            # if the value is empty, it means that the user wants to use the default value
             pass
         else:
             try:
@@ -375,6 +376,7 @@ class ActionInputs:
 
         # Changed
         if len(values[1]) == 0:
+            # if the value is empty, it means that the user wants to use the default value
             pass
         else:
             try:
@@ -384,6 +386,7 @@ class ActionInputs:
 
         # Changed per file
         if len(values[2]) == 0:
+            # if the value is empty, it means that the user wants to use the default value
             pass
         else:
             try:

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -213,7 +213,9 @@ class ActionInputs:
 
                 overall = float(parts[0]) if len(parts[0]) > 0 else ActionInputs.get_min_coverage_overall()
                 changed = float(parts[1]) if len(parts[1]) > 0 else ActionInputs.get_min_coverage_changed_files()
-                changed_per_file = float(parts[2]) if len(parts[2]) > 0 else ActionInputs.get_min_coverage_per_changed_file()
+                changed_per_file = (
+                    float(parts[2]) if len(parts[2]) > 0 else ActionInputs.get_min_coverage_per_changed_file()
+                )
                 result[f_name] = (overall, changed, changed_per_file)
             return result
 
@@ -355,7 +357,8 @@ class ActionInputs:
         # Check if the module threshold is the format containing '*'
         if module_threshold_parts[1].count("*") != 2:
             return [
-                f"'module-threshold':'{module_threshold_parts[1]}' must contain two '*' to split overall, changed files and changed per file threshold."
+                f"'module-threshold':'{module_threshold_parts[1]}' must contain two '*' to split overall, "
+                f"changed files and changed per file threshold."
             ]
 
         errors = []
@@ -488,9 +491,7 @@ class ActionInputs:
         ):  # type: ignore[union-attr]
             errors.append("'comment-mode' is 'module' but 'modules' is not defined.")
 
-        modules_thresholds: dict[str, tuple[Optional[float], Optional[float]]] | str = (
-            ActionInputs.get_modules_thresholds(raw=True)
-        )
+        modules_thresholds: dict[str, tuple[float, float, float]] | str = ActionInputs.get_modules_thresholds(raw=True)
         if not isinstance(modules_thresholds, str):
             errors.append("'modules-thresholds' must be a string or not defined.")
         else:

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -88,6 +88,13 @@ class ActionInputs:
         return float(get_action_input(MIN_COVERAGE_CHANGED_FILES, "0.0"))
 
     @staticmethod
+    def get_min_coverage_per_changed_file() -> float:
+        """
+        Get the minimum coverage per changed file from the action inputs.
+        """
+        return float(get_action_input("min-coverage-per-changed-file", "0.0"))
+
+    @staticmethod
     def get_title(report_name: Optional[str] = None) -> str:
         """
         Get the title from the action inputs.
@@ -179,21 +186,21 @@ class ActionInputs:
         return d
 
     @staticmethod
-    def get_modules_thresholds(raw: bool = False) -> dict[str, tuple[Optional[float], Optional[float]]] | str:
+    def get_modules_thresholds(raw: bool = False) -> dict[str, tuple[float, float, float]] | str:
         """
         Get the modules thresholds from the action inputs.
         """
 
-        def parse_module_thresholds(received: str) -> dict[str, tuple[Optional[float], Optional[float]]]:
+        def parse_module_thresholds(received: str) -> dict[str, tuple[float, float, float]]:
             if len(received) == 0:
                 return {}
 
-            result = dict[str, tuple[Optional[float], Optional[float]]]()
+            result = dict[str, tuple[float, float, float]]()
             split_by: str = "," if "," in received else "\n"
             mts: list[str] = received.split(split_by)
             for mt in mts:
                 # detect presence of '#' char - user commented out the line
-                if "#" in mt:
+                if "#" in mt.lstrip():
                     continue
 
                 # format string, clean up, ...
@@ -203,9 +210,11 @@ class ActionInputs:
                 f_name = name.strip()
                 f_values = values.strip()
                 parts = f_values.split("*")
-                overall = float(parts[0]) if len(parts[0]) > 0 else None
-                changed = float(parts[1]) if len(parts[1]) > 1 else None
-                result[f_name] = (overall, changed)
+
+                overall = float(parts[0]) if len(parts[0]) > 0 else ActionInputs.get_min_coverage_overall()
+                changed = float(parts[1]) if len(parts[1]) > 0 else ActionInputs.get_min_coverage_changed_files()
+                changed_per_file = float(parts[2]) if len(parts[2]) > 0 else ActionInputs.get_min_coverage_per_changed_file()
+                result[f_name] = (overall, changed, changed_per_file)
             return result
 
         raw_input = get_action_input(MODULES_THRESHOLDS, "").strip()
@@ -344,10 +353,9 @@ class ActionInputs:
             return [f"Module threshold with 'name':'{module_threshold_parts[0]}' must have a non-empty threshold."]
 
         # Check if the module threshold is the format containing '*'
-        if "*" not in module_threshold_parts[1]:
+        if module_threshold_parts[1].count("*") != 2:
             return [
-                f"'module_threshold':'{module_threshold_parts[1]}' must contain '*' to split overall "
-                f"and changed files threshold."
+                f"'module-threshold':'{module_threshold_parts[1]}' must contain two '*' to split overall, changed files and changed per file threshold."
             ]
 
         errors = []
@@ -360,7 +368,7 @@ class ActionInputs:
             try:
                 float(values[0])
             except ValueError:
-                errors.append(f"'module_threshold' overall value '{values[0]}' must be a float or None.")
+                errors.append(f"'module-threshold' overall value '{values[0]}' must be a float or None.")
 
         # Changed
         if len(values[1]) == 0:
@@ -369,7 +377,16 @@ class ActionInputs:
             try:
                 float(values[1])
             except ValueError:
-                errors.append(f"'module_threshold' changed files value '{values[1]}' must be a float or None.")
+                errors.append(f"'module-threshold' changed files value '{values[1]}' must be a float or None.")
+
+        # Changed per file
+        if len(values[2]) == 0:
+            pass
+        else:
+            try:
+                float(values[2])
+            except ValueError:
+                errors.append(f"'module-threshold' changed per file value '{values[2]}' must be a float or None.")
 
         return errors
 
@@ -424,6 +441,14 @@ class ActionInputs:
             or min_coverage_changed_files > 100
         ):
             errors.append("'min-coverage-changed-files' must be a float between 0 and 100.")
+
+        min_coverage_per_changed_file = ActionInputs.get_min_coverage_per_changed_file()
+        if (
+            not isinstance(min_coverage_per_changed_file, float)
+            or min_coverage_per_changed_file < 0
+            or min_coverage_per_changed_file > 100
+        ):
+            errors.append("'min-coverage-per-changed-file' must be a float between 0 and 100.")
 
         metric = ActionInputs.get_metric()
         if not isinstance(metric, str) or metric not in MetricTypeEnum:
@@ -515,6 +540,7 @@ class ActionInputs:
             "\n"
             f"Minimum coverage overall: {ActionInputs.get_min_coverage_overall()}\n"
             f"Minimum coverage changed files: {ActionInputs.get_min_coverage_changed_files()}\n"
+            f"Minimum coverage per changed file: {ActionInputs.get_min_coverage_per_changed_file()}\n"
             "\n"
             f"Modules: {ActionInputs.get_modules()}\n"
             f"Modules thresholds: {ActionInputs.get_modules_thresholds()}\n"

--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -24,6 +24,7 @@ class CoverageEvaluator:
     to check if they pass the thresholds.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         report_files_coverage: list[ReportFileCoverage],
@@ -267,7 +268,9 @@ class CoverageEvaluator:
             EvaluatedReportCoverage: The evaluated coverage of the module
         """
         # get the thresholds for the module
-        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(evaluated_coverage.name)
+        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(
+            evaluated_coverage.name
+        )
         evaluated_coverage.overall_coverage_threshold = overall_threshold
         evaluated_coverage.changed_files_threshold = changed_files_threshold
         evaluated_coverage.per_changed_file_threshold = changed_per_file_threshold
@@ -306,7 +309,9 @@ class CoverageEvaluator:
             EvaluatedReportCoverage: The evaluated coverage of the report
         """
         # get the thresholds for the report
-        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(report_coverage.module_name)
+        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(
+            report_coverage.module_name
+        )
         evaluated_coverage_report.overall_coverage_threshold = overall_threshold
         evaluated_coverage_report.changed_files_threshold = changed_files_threshold
         evaluated_coverage_report.per_changed_file_threshold = changed_per_file_threshold
@@ -339,7 +344,8 @@ class CoverageEvaluator:
             # evaluate the changed files
             for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
                 evaluated_coverage_report.changed_files_passed[key] = (
-                    changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric()) >= changed_per_file_threshold
+                    changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric())
+                    >= changed_per_file_threshold
                 )
 
         return evaluated_coverage_report

--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -29,6 +29,7 @@ class CoverageEvaluator:
         report_files_coverage: list[ReportFileCoverage],
         global_min_coverage_overall: float,
         global_min_coverage_changed_files: float,
+        global_min_coverage_changed_per_file: float,
         modules: Optional[dict[str, Module]] = None,
     ):
         # input data stats
@@ -37,6 +38,7 @@ class CoverageEvaluator:
         # thresholds
         self._global_min_coverage_overall: float = global_min_coverage_overall
         self._global_min_coverage_changed_files: float = global_min_coverage_changed_files
+        self._global_min_coverage_changed_per_file = global_min_coverage_changed_per_file
         self._modules: dict[str, Module] = modules if modules is not None else {}
 
         # *** output data for the comment(s) ***
@@ -211,7 +213,7 @@ class CoverageEvaluator:
                     changed_files_violations.append(
                         f"Report '{report_path}' changed file '{key}' coverage "
                         f"{evaluated_coverage_report.changed_files_coverage_reached[key]} is below the threshold "
-                        f"{evaluated_coverage_report.changed_files_threshold}."
+                        f"{evaluated_coverage_report.per_changed_file_threshold}."
                     )
 
         # Add all violations to the list depending on the sensitivity and comment mode
@@ -265,9 +267,10 @@ class CoverageEvaluator:
             EvaluatedReportCoverage: The evaluated coverage of the module
         """
         # get the thresholds for the module
-        overall_threshold, changed_files_threshold = self._set_thresholds(evaluated_coverage.name)
+        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(evaluated_coverage.name)
         evaluated_coverage.overall_coverage_threshold = overall_threshold
         evaluated_coverage.changed_files_threshold = changed_files_threshold
+        evaluated_coverage.per_changed_file_threshold = changed_per_file_threshold
 
         if evaluated_coverage.overall_coverage.covered == 0 and evaluated_coverage.overall_coverage.missed == 0:
             evaluated_coverage.overall_coverage_reached = 0.0
@@ -303,9 +306,10 @@ class CoverageEvaluator:
             EvaluatedReportCoverage: The evaluated coverage of the report
         """
         # get the thresholds for the report
-        overall_threshold, changed_files_threshold = self._set_thresholds(report_coverage.module_name)
+        overall_threshold, changed_files_threshold, changed_per_file_threshold = self._set_thresholds(report_coverage.module_name)
         evaluated_coverage_report.overall_coverage_threshold = overall_threshold
         evaluated_coverage_report.changed_files_threshold = changed_files_threshold
+        evaluated_coverage_report.per_changed_file_threshold = changed_per_file_threshold
 
         if (
             evaluated_coverage_report.overall_coverage.covered == 0
@@ -335,12 +339,12 @@ class CoverageEvaluator:
             # evaluate the changed files
             for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
                 evaluated_coverage_report.changed_files_passed[key] = (
-                    changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric()) >= changed_files_threshold
+                    changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric()) >= changed_per_file_threshold
                 )
 
         return evaluated_coverage_report
 
-    def _set_thresholds(self, module_name: str) -> tuple[float, float]:
+    def _set_thresholds(self, module_name: str) -> tuple[float, float, float]:
         """
         Sets the coverage thresholds for the report.
         """
@@ -355,8 +359,14 @@ class CoverageEvaluator:
                 if self._modules[module_name].min_coverage_changed_files is not None
                 else self._global_min_coverage_changed_files
             )
+            changed_per_file_threshold = (
+                self._modules[module_name].min_coverage_per_changed_file
+                if self._modules[module_name].min_coverage_per_changed_file is not None
+                else self._global_min_coverage_changed_per_file
+            )
         else:
             overall_threshold = self._global_min_coverage_overall
             changed_files_threshold = self._global_min_coverage_changed_files
+            changed_per_file_threshold = self._global_min_coverage_changed_per_file
 
-        return overall_threshold, changed_files_threshold
+        return overall_threshold, changed_files_threshold, changed_per_file_threshold

--- a/jacoco_report/generator/module_pr_comment_generator.py
+++ b/jacoco_report/generator/module_pr_comment_generator.py
@@ -91,7 +91,7 @@ class ModulePRCommentGenerator(MultiPRCommentGenerator):
                 line = "\n| {} | {}% | {}% | {} |".format(
                     f"[{filename}]({file_as_link_to_diff})",
                     evaluated_report_coverage.changed_files_coverage_reached[changed_file_key],
-                    evaluated_report_coverage.changed_files_threshold,
+                    evaluated_report_coverage.per_changed_file_threshold,
                     (p if evaluated_report_coverage.changed_files_passed[changed_file_key] else f),
                 )
             else:
@@ -112,7 +112,7 @@ class ModulePRCommentGenerator(MultiPRCommentGenerator):
                 line = "\n| {} | {}% | {}% | {}{}% | {} |".format(
                     f"[{filename}]({file_as_link_to_diff})",
                     evaluated_report_coverage.changed_files_coverage_reached[changed_file_key],
-                    evaluated_report_coverage.changed_files_threshold,
+                    evaluated_report_coverage.per_changed_file_threshold,
                     "+" if diff > 0.001 else "",
                     round(diff, 2),
                     (p if evaluated_report_coverage.changed_files_passed[changed_file_key] else f),

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -391,7 +391,7 @@ class PRCommentGenerator:
                 line = "\n| {} | {}% | {}% | {} |".format(
                     f"[{filename}]({file_as_link_to_diff})",
                     evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key],
-                    evaluated_reports_coverage[ecr_key].changed_files_threshold,
+                    evaluated_reports_coverage[ecr_key].per_changed_file_threshold,
                     (p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f),
                 )
                 lines.append(line)
@@ -443,7 +443,7 @@ class PRCommentGenerator:
                 line = "\n| {} | {}% | {}% | {}{}% | {} |".format(
                     f"[{filename}]({file_as_link_to_diff})",
                     evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key],
-                    evaluated_reports_coverage[ecr_key].changed_files_threshold,
+                    evaluated_reports_coverage[ecr_key].per_changed_file_threshold,
                     "+" if diff > 0.001 else "",
                     round(diff, 2),
                     (p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f),

--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -103,6 +103,7 @@ class JaCoCoReport:
             report_files_coverage=report_files_coverage,
             global_min_coverage_overall=ActionInputs.get_min_coverage_overall(),
             global_min_coverage_changed_files=ActionInputs.get_min_coverage_changed_files(),
+            global_min_coverage_changed_per_file=ActionInputs.get_min_coverage_per_changed_file(),
             modules=modules,
         )
         evaluator.evaluate()
@@ -111,6 +112,7 @@ class JaCoCoReport:
             report_files_coverage=bs_report_files_coverage,
             global_min_coverage_overall=ActionInputs.get_min_coverage_overall(),
             global_min_coverage_changed_files=ActionInputs.get_min_coverage_changed_files(),
+            global_min_coverage_changed_per_file=ActionInputs.get_min_coverage_per_changed_file(),
             modules=modules,
         )
 

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -31,6 +31,8 @@ class EvaluatedReportCoverage:
         self.changed_files_threshold: float = 0.0
         self.changed_files_coverage_reached: dict[str, float] = {}
 
+        self.per_changed_file_threshold: float = 0.0
+
     def to_dict(self) -> dict:
         """Convert object to dictionary for JSON serialization"""
         return {
@@ -48,4 +50,5 @@ class EvaluatedReportCoverage:
             "changed_files_passed": self.changed_files_passed,
             "changed_files_threshold": self.changed_files_threshold,
             "changed_files_coverage_reached": self.changed_files_coverage_reached,
+            "per_changed_file_threshold": self.per_changed_file_threshold,
         }

--- a/jacoco_report/model/module.py
+++ b/jacoco_report/model/module.py
@@ -9,8 +9,15 @@ class Module:
     A class that represents a module in a project.
     """
 
-    def __init__(self, name: str, unique_path: str, min_coverage_overall: float, min_coverage_changed_files: float,
-                 min_coverage_changed_per_file: float):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        name: str,
+        unique_path: str,
+        min_coverage_overall: float,
+        min_coverage_changed_files: float,
+        min_coverage_changed_per_file: float,
+    ):
         """
         Constructor of the class.
 
@@ -19,7 +26,8 @@ class Module:
             unique_path (str): The root path of the module.
             min_coverage_overall (float): The minimum coverage that the module should have.
             min_coverage_changed_files (float): The minimum coverage that the module should have in the changed files.
-            min_coverage_changed_per_file (float): The minimum coverage that the module should have in the changed files per file.
+            min_coverage_changed_per_file (float): The minimum coverage that the module should have in the changed files
+             per file.
         """
         self.name = name
         self.root_path = unique_path

--- a/jacoco_report/model/module.py
+++ b/jacoco_report/model/module.py
@@ -9,7 +9,8 @@ class Module:
     A class that represents a module in a project.
     """
 
-    def __init__(self, name: str, unique_path: str, min_coverage_overall: float, min_coverage_changed_files: float):
+    def __init__(self, name: str, unique_path: str, min_coverage_overall: float, min_coverage_changed_files: float,
+                 min_coverage_changed_per_file: float):
         """
         Constructor of the class.
 
@@ -18,8 +19,10 @@ class Module:
             unique_path (str): The root path of the module.
             min_coverage_overall (float): The minimum coverage that the module should have.
             min_coverage_changed_files (float): The minimum coverage that the module should have in the changed files.
+            min_coverage_changed_per_file (float): The minimum coverage that the module should have in the changed files per file.
         """
         self.name = name
         self.root_path = unique_path
         self.min_coverage_overall = min_coverage_overall
         self.min_coverage_changed_files = min_coverage_changed_files
+        self.min_coverage_per_changed_file = min_coverage_changed_per_file

--- a/jacoco_report/parser/module_parser.py
+++ b/jacoco_report/parser/module_parser.py
@@ -13,7 +13,7 @@ class ModuleParser:
     """
 
     @staticmethod
-    def parse(modules: dict[str, str], modules_thresholds: dict[str, tuple[float, float]]) -> dict[str, Module]:
+    def parse(modules: dict[str, str], modules_thresholds: dict[str, tuple[float, float, float]]) -> dict[str, Module]:
         """
         Parse the module information from the action inputs.
         If no threshold is provided for a module, the default threshold is used.
@@ -28,12 +28,10 @@ class ModuleParser:
         module_dict = {}
 
         for name, path in modules.items():
-            overall, changed = modules_thresholds.get(name, (None, None))
-            module_dict[name] = Module(
-                name,
-                path,
-                overall if overall is not None else ActionInputs.get_min_coverage_overall(),
-                changed if changed is not None else ActionInputs.get_min_coverage_changed_files(),
-            )
+            overall, changed, changed_per_file = modules_thresholds.get(name, (
+                ActionInputs.get_min_coverage_overall(),
+                ActionInputs.get_min_coverage_changed_files(),
+                ActionInputs.get_min_coverage_per_changed_file(),))
+            module_dict[name] = Module(name, path, overall, changed, changed_per_file)
 
         return module_dict

--- a/jacoco_report/parser/module_parser.py
+++ b/jacoco_report/parser/module_parser.py
@@ -28,10 +28,14 @@ class ModuleParser:
         module_dict = {}
 
         for name, path in modules.items():
-            overall, changed, changed_per_file = modules_thresholds.get(name, (
-                ActionInputs.get_min_coverage_overall(),
-                ActionInputs.get_min_coverage_changed_files(),
-                ActionInputs.get_min_coverage_per_changed_file(),))
+            overall, changed, changed_per_file = modules_thresholds.get(
+                name,
+                (
+                    ActionInputs.get_min_coverage_overall(),
+                    ActionInputs.get_min_coverage_changed_files(),
+                    ActionInputs.get_min_coverage_per_changed_file(),
+                ),
+            )
             module_dict[name] = Module(name, path, overall, changed, changed_per_file)
 
         return module_dict

--- a/jacoco_report/parser/module_parser.py
+++ b/jacoco_report/parser/module_parser.py
@@ -20,7 +20,7 @@ class ModuleParser:
 
         Parameters:
             modules (dict[str, str]): The module names and their paths.
-            modules_thresholds (dict[str, (float, float)]): The module names and their thresholds.
+            modules_thresholds (dict[str, (float, float, float)]): The module names and their thresholds.
 
         Returns:
             dict[str, Module]: The module names and their Module objects.

--- a/tests/evaluator/test_coverage_evaluator.py
+++ b/tests/evaluator/test_coverage_evaluator.py
@@ -49,7 +49,8 @@ def evaluator(sample_report_file_coverage):
     return CoverageEvaluator(
         report_files_coverage=[sample_report_file_coverage],
         global_min_coverage_overall=50.0,
-        global_min_coverage_changed_files=50.0
+        global_min_coverage_changed_files=50.0,
+        global_min_coverage_changed_per_file=50.0
     )
 
 def test_evaluate_overall_coverage(evaluator):
@@ -264,18 +265,20 @@ def test_evaluate_module_with_patched_thresholds(mocker):
         path="sample_report.xml",
         name="Sample Report Name",
         overall_coverage=overall_coverage,
-        changed_files_coverage=changed_files_coverage
+        changed_files_coverage=changed_files_coverage,
+
     )
 
     # Create an instance of CoverageEvaluator
     evaluator = CoverageEvaluator(
         report_files_coverage=[report_file_coverage],
         global_min_coverage_overall=50.0,
-        global_min_coverage_changed_files=50.0
+        global_min_coverage_changed_files=50.0,
+        global_min_coverage_changed_per_file=50.0
     )
 
     # Patch the _set_thresholds method
-    mocker.patch.object(evaluator, '_set_thresholds', return_value=(50.0, 50.0))
+    mocker.patch.object(evaluator, '_set_thresholds', return_value=(50.0, 50.0, 50.0))
 
     # Create an evaluated coverage module with no coverage
     evaluated_coverage_module = EvaluatedReportCoverage("module-a")

--- a/tests/generator/test_pr_comment_generator.py
+++ b/tests/generator/test_pr_comment_generator.py
@@ -17,6 +17,7 @@ def test_evaluator(mocker):
         report_files_coverage=[],
         global_min_coverage_overall=80.0,
         global_min_coverage_changed_files=80.0,
+        global_min_coverage_changed_per_file=80.0,
         modules={},
     )
     ce.total_coverage_overall = 85.2
@@ -55,7 +56,7 @@ def test_get_modules_table_with_baseline_with_modules(pr_comment_generator, mock
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
     mocker.patch("jacoco_report.generator.pr_comment_generator.PRCommentGenerator._calculate_baseline_module_diffs", return_value=(1.1, 2.0))
 
-    pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0)
+    pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0, 80.0)
 
     pr_comment_generator.evaluator.evaluated_modules_coverage["test"] = EvaluatedReportCoverage()
     pr_comment_generator.evaluator.evaluated_modules_coverage["test"].name = "test"
@@ -73,7 +74,7 @@ def test_generate_modules_table_with_baseline(pr_comment_generator, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=True)
     mocker.patch("jacoco_report.generator.pr_comment_generator.PRCommentGenerator._calculate_baseline_module_diffs", return_value=(1.1, 2.0))
 
-    pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0)
+    pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0, 80.0)
 
     pr_comment_generator.evaluator.evaluated_modules_coverage["test"] = EvaluatedReportCoverage()
     pr_comment_generator.evaluator.evaluated_modules_coverage["test"].name = "test"
@@ -168,7 +169,7 @@ def test_generate_changed_files_table_with_baseline(pr_comment_generator, mocker
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 75.0% | +10.0% | ✅ |"""
+| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 0.0% | +10.0% | ✅ |"""
     assert table == expected_table
 
 def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage(pr_comment_generator, mocker):
@@ -208,7 +209,7 @@ def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 75.0% | 0.0% | ✅ |"""
+| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 0.0% | 0.0% | ✅ |"""
     assert table == expected_table
 
 def test_generate_changed_files_table_with_baseline_no_changed_file(pr_comment_generator, mocker):
@@ -248,5 +249,5 @@ def test_generate_changed_files_table_with_baseline_no_changed_file(pr_comment_g
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 75.0% | 0.0% | ✅ |"""
+| [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 0.0% | 0.0% | ✅ |"""
     assert table == expected_table

--- a/tests/model/test_module.py
+++ b/tests/model/test_module.py
@@ -3,9 +3,11 @@ from jacoco_report.model.module import Module
 # __init__
 
 def test_initialization():
-    module = Module(name="module_name", unique_path="some/path", min_coverage_overall=75.0, min_coverage_changed_files=80.0)
+    module = Module(name="module_name", unique_path="some/path", min_coverage_overall=75.0,
+                    min_coverage_changed_files=80.0, min_coverage_changed_per_file=80.0)
 
     assert module.name == "module_name"
     assert module.min_coverage_overall == 75.0
     assert module.min_coverage_changed_files == 80.0
+    assert module.min_coverage_per_changed_file == 80.0
     assert module.root_path == "some/path"

--- a/tests/parser/test_jacoco_report_parser.py
+++ b/tests/parser/test_jacoco_report_parser.py
@@ -39,7 +39,7 @@ def parser():
 
 @pytest.fixture
 def parser_with_modules():
-    module: Module = Module("module_a", "path/to/module_a", 50, 50)
+    module: Module = Module("module_a", "path/to/module_a", 50, 50, 50)
     modules = {
         "module_a": module,
     }

--- a/tests/parser/test_module_parser.py
+++ b/tests/parser/test_module_parser.py
@@ -9,8 +9,8 @@ def test_parse():
         "module2": "path/to/module2"
     }
     modules_thresholds = {
-        "module1": (75.0, 80.0),
-        "module2": (85.0, 90.0)
+        "module1": (75.0, 80.0, 80.0),
+        "module2": (85.0, 90.0, 80.0)
     }
 
     parsed_modules = ModuleParser.parse(modules, modules_thresholds)
@@ -20,10 +20,12 @@ def test_parse():
     assert parsed_modules["module1"].name == "module1"
     assert parsed_modules["module1"].min_coverage_overall == 75.0
     assert parsed_modules["module1"].min_coverage_changed_files == 80.0
+    assert parsed_modules["module1"].min_coverage_per_changed_file == 80.0
     assert isinstance(parsed_modules["module2"], Module)
     assert parsed_modules["module2"].name == "module2"
     assert parsed_modules["module2"].min_coverage_overall == 85.0
     assert parsed_modules["module2"].min_coverage_changed_files == 90.0
+    assert parsed_modules["module2"].min_coverage_per_changed_file == 80.0
 
 
 def test_parse_missing_thresholds(mocker):
@@ -32,11 +34,12 @@ def test_parse_missing_thresholds(mocker):
         "module2": "path/to/module2"
     }
     modules_thresholds = {
-        "module1": (75.0, 80.0)
+        "module1": (75.0, 80.0, 80.0)
     }
 
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_overall", return_value=50.0)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_changed_files", return_value=60.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_per_changed_file", return_value=60.0)
 
     parsed_modules = ModuleParser.parse(modules, modules_thresholds)
 
@@ -45,7 +48,9 @@ def test_parse_missing_thresholds(mocker):
     assert parsed_modules["module1"].name == "module1"
     assert parsed_modules["module1"].min_coverage_overall == 75.0
     assert parsed_modules["module1"].min_coverage_changed_files == 80.0
+    assert parsed_modules["module1"].min_coverage_per_changed_file == 80.0
     assert isinstance(parsed_modules["module2"], Module)
     assert parsed_modules["module2"].name == "module2"
     assert parsed_modules["module2"].min_coverage_overall == 50.0
     assert parsed_modules["module2"].min_coverage_changed_files == 60.0
+    assert parsed_modules["module2"].min_coverage_per_changed_file == 60.0

--- a/tests/test_jacoco_report.py
+++ b/tests/test_jacoco_report.py
@@ -271,9 +271,9 @@ comment_more_files_single_detailed_instruction_no_modules = """**JaCoCo Coverage
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_no_modules_with_bs = """**JaCoCo Coverage Report**
 
@@ -296,9 +296,9 @@ comment_more_files_single_detailed_instruction_no_modules_with_bs = """**JaCoCo 
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules = """**JaCoCo Coverage Report**
 
@@ -328,9 +328,9 @@ comment_more_files_single_detailed_instruction_with_modules = """**JaCoCo Covera
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | ❌ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | ❌ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_with_bs = """**JaCoCo Coverage Report**
 
@@ -360,9 +360,9 @@ comment_more_files_single_detailed_instruction_with_modules_with_bs = """**JaCoC
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_with_bs_fail_module = """**JaCoCo Coverage Report**
 
@@ -386,9 +386,9 @@ comment_more_files_single_detailed_instruction_with_modules_with_bs_fail_module 
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_partial_modules_1 = """**JaCoCo Coverage Report**
 
@@ -412,9 +412,9 @@ comment_more_files_single_detailed_instruction_with_partial_modules_1 = """**JaC
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_partial_modules_2 = """**JaCoCo Coverage Report**
 
@@ -438,9 +438,9 @@ comment_more_files_single_detailed_instruction_with_partial_modules_2 = """**JaC
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_partial_modules_3 = """**JaCoCo Coverage Report**
 
@@ -463,9 +463,9 @@ comment_more_files_single_detailed_instruction_with_partial_modules_3 = """**JaC
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed = """**JaCoCo Coverage Report**
 
@@ -495,9 +495,9 @@ comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed_with_bs = """**JaCoCo Coverage Report**
 
@@ -527,9 +527,9 @@ comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_skip_changed = """**JaCoCo Coverage Report**
 
@@ -551,9 +551,9 @@ comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |"""
 
 comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_skip_changed_with_bs = """**JaCoCo Coverage Report**
 
@@ -575,9 +575,9 @@ comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |"""
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
 
 comment_multi_minimalist_instruction = [
 """**Report: user-info: API Module Report**
@@ -857,7 +857,7 @@ comment_multi_detailed_instruction_no_modules = [
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |""",
 """**Report: user-info: Implementation Module Report**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -867,7 +867,7 @@ comment_multi_detailed_instruction_no_modules = [
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |""",
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |""",
 """**Report: Module Small Report**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -888,7 +888,7 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |""",
 """**Report: user-info:  Controller Module Report**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -951,21 +951,21 @@ comment_multi_detailed_instruction_no_modules_with_bs = [
 """**Report: user-info:  Controller Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 93.0% | 75.0% | +93.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 75.0% | +97.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +90.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
 """**Report: user-info: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 75.0% | 0.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |""",
 """**Report: notification: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 75.0% | +95.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 ]
 
 comment_multi_detailed_instruction_with_modules = [
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 97.0% | 29.0% | ✅ |\n| **Changed Files** | 0.0% | 37.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 21.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 21.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | ✅ |""",
 """**Report: user-info: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 95.0% | 21.0% | ✅ |\n| **Changed Files** | 0.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 95.0% | 22.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: Plugins Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 92.0% | 22.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 21.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | ✅ |""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 20.0% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | ❌ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | ❌ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 21.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 20.0% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | ❌ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | ❌ |""",
 """**Report: user-info:  Controller Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 93.0% | 21.0% | ✅ |\n| **Changed Files** | 0.0% | 59.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 22.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 ]
@@ -973,41 +973,41 @@ comment_multi_detailed_instruction_with_modules = [
 comment_multi_detailed_instruction_with_modules_with_bs = [
 """**Report: notification: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 22.0% | +95.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: user-info: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 21.0% | 0.0% | ✅ |\n| **Changed Files** | 0.0% | 59.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |""",
 """**Report: notification: Plugins Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 92.0% | 22.0% | +92.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 29.0% | +97.0% | ✅ |\n| **Changed Files** | 0.0% | 37.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: user-info:  Controller Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 93.0% | 21.0% | +93.0% | ✅ |\n| **Changed Files** | 0.0% | 59.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 22.0% | +90.0% | ✅ |\n| **Changed Files** | 0.0% | 60.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 ]
 
 comment_multi_detailed_instruction_with_modules_with_bs_fail_module = [
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 100.0% | +97.0% | ❌ |\n| **Changed Files** | 0.0% | 37.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_with_bs_partial_modules_2 = [
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 20.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 91.0% | -5.0% | ❌ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 100.0% | +97.0% | ❌ |\n| **Changed Files** | 0.0% | 37.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_with_bs_partial_modules_3 = [
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 100.0% | +97.0% | ❌ |\n| **Changed Files** | 0.0% | 37.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_report_1 = [
-    """**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
-    """**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+    """**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 21.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 59.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
+    """**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
     """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 100.0% | +97.0% | ❌ |\n| **Changed Files** | 0.0% | 37.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-    """**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |""",
+    """**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 21.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 59.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed = [
@@ -1016,34 +1016,34 @@ comment_multi_detailed_instruction_with_modules_no_module_thresholds_not_skip_ch
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 97.0% | 75.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 """**Report: user-info: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 95.0% | 75.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 95.0% | 75.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 75.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 75.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |""",
 """**Report: notification: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 75.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports.""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed_with_bs = [
 """**Report: notification: Plugins Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 92.0% | 75.0% | +92.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: user-info:  Controller Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 93.0% | 75.0% | +93.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 """**Report: user-info: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 75.0% | 0.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |""",
 """**Report: Module Small Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 75.0% | +97.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: API Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 95.0% | 75.0% | +95.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 """**Report: notification: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +90.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_no_module_thresholds_skip_changed = [
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |""",
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 75.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 91.33% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 90.0% | 75.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Status |\n|----------------------|----------|-----------|--------|\n| **Overall**       | 88.0% | 75.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |""",
 ]
 
 comment_multi_detailed_instruction_with_modules_no_module_thresholds_skip_changed_with_bs = [
-"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |""",
-"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
-"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+"""**Report: user-info: Client HTTP Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 90.0% | 75.0% | +80.0% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | +80.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |""",
+"""**Report: user-info: Implementation Module Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 88.0% | 75.0% | +8.0% | ✅ |\n| **Changed Files** | 88.0% | 80.0% | +8.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
+"""**Report: Module Large Report**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 ]
 
 comment_module_detailed_instruction_with_modules_with_bs = [
@@ -1080,8 +1080,8 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1095,7 +1095,7 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1128,8 +1128,8 @@ comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1143,7 +1143,7 @@ comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1176,8 +1176,8 @@ comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1191,7 +1191,7 @@ comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1225,9 +1225,9 @@ comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1260,8 +1260,8 @@ comment_module_detailed_instruction_with_modules_with_bs_report_1 = [
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | +8.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | +8.0% | ✅ |""",
 """**Module: Unknown**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1275,7 +1275,7 @@ comment_module_detailed_instruction_with_modules_with_bs_report_1 = [
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1322,7 +1322,7 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | -5.0% | ❌ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | -5.0% | ❌ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1538,8 +1538,8 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 59.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 59.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 55.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 55.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -1553,7 +1553,7 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 91.0% | ❌ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 90.5% | ❌ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -1612,8 +1612,8 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -1627,7 +1627,7 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |""",
 """**Module: module small**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -1679,9 +1679,9 @@ No changed file in reports.""",
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
-"""**Module: module_large**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| Report | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |\n|--------|----------|-----------|------------|--------|\n| `Module Large Report` | 91.33% / 90.0% | 75.0% / 80.0% | -4.17% / -5.0% | ✅/✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
+"""**Module: module_large**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 91.33% | 75.0% | -4.17% | ✅ |\n| **Changed Files** | 90.0% | 80.0% | -5.0% | ✅ |\n\n| Report | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |\n|--------|----------|-----------|------------|--------|\n| `Module Large Report` | 91.33% / 90.0% | 75.0% / 80.0% | -4.17% / -5.0% | ✅/✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 """**Module: module small**\n\n| Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |\n|-------------------|-----|-----|-----|----|\n| **Overall**       | 97.0% | 75.0% | +97.0% | ✅ |\n| **Changed Files** | 0.0% | 80.0% | 0.0% | ✅ |\n\n| Report | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |\n|--------|----------|-----------|------------|--------|\n| `Module Small Report` | 97.0% / 0.0% | 75.0% / 80.0% | 0.0% / 0.0% | ✅/✅ |\n\n| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports.""",
 ]
 
@@ -1700,8 +1700,8 @@ comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_chang
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Status |
@@ -1715,7 +1715,7 @@ comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_chang
 
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |""",
 ]
 
 comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_changed_with_bs = [
@@ -1733,8 +1733,8 @@ comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_chang
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 80.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 80.0% | +8.0% | ✅ |""",
+| [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |""",
 """**Module: module_large**
 
 | Metric (instruction) | Coverage | Threshold | Δ Coverage | Status |
@@ -1748,7 +1748,7 @@ comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_chang
 
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
-| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 80.0% | -5.0% | ✅ |""",
+| [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |""",
 ]
 
 changed_files = [
@@ -1786,48 +1786,48 @@ modules_partial_definition_3_reports = {
 }
 
 modules_thresholds = {
-    "context/notification": (22.0, 60.0),
-    "context/user-info": (21.0, 59.0),
-    "module_large": (20.0, 91.0),
-    "module small": (29.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "context/user-info": (21.0, 59.0, 55.0),
+    "module_large": (20.0, 91.0, 90.5),
+    "module small": (29.0, 37.0, 35.0),
 }
 
 modules_thresholds_100 = {
-    "context/notification": (22.0, 60.0),
-    "context/user-info": (21.0, 59.0),
-    "module_large": (20.0, 91.0),
-    "module small": (100.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "context/user-info": (21.0, 59.0, 55.0),
+    "module_large": (20.0, 91.0, 90.5),
+    "module small": (100.0, 37.0, 35.0),
 }
 
 modules_thresholds_89 = {
-    "context/notification": (22.0, 60.0),
-    "context/user-info": (89.0, 59.0),
-    "module_large": (20.0, 91.0),
-    "module small": (100.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "context/user-info": (89.0, 59.0, 55.0),
+    "module_large": (20.0, 91.0, 90.5),
+    "module small": (100.0, 37.0, 35.0),
 }
 
 modules_thresholds_100_partial_definition_1_report = {
-    "context/notification": (22.0, 60.0),
-    "context/user-info": (21.0, 59.0),
-    "module small": (100.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "context/user-info": (21.0, 59.0, 55.0),
+    "module small": (100.0, 37.0, 35.0),
 }
 
 modules_thresholds_100_partial_definition_2_reports = {
-    "context/notification": (22.0, 60.0),
-    "module_large": (20.0, 91.0),
-    "module small": (100.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "module_large": (20.0, 91.0, 90.5),
+    "module small": (100.0, 37.0, 35.0),
 }
 
 modules_thresholds_100_partial_definition_3_reports = {
-    "context/notification": (22.0, 60.0),
-    "module small": (100.0, 37.0),
+    "context/notification": (22.0, 60.0, 55.0),
+    "module small": (100.0, 37.0, 35.0),
 }
 
 modules_thresholds_100_all = {
-    "context/notification": (100.0, 100.0),
-    "context/user-info": (100.0, 100.0),
-    "module_large": (100.0, 100.0),
-    "module small": (100.0, 100.0),
+    "context/notification": (100.0, 100.0, 100.0),
+    "context/user-info": (100.0, 100.0, 100.0),
+    "module_large": (100.0, 100.0, 100.0),
+    "module small": (100.0, 100.0, 100.0),
 }
 
 @pytest.fixture
@@ -1946,8 +1946,8 @@ more_source_files_scenarios = [
     ("10", CommentModeEnum.SINGLE, SensitivityEnum.SUMMARY, modules, {}, changed_files, [comment_more_files_single_summary_instruction_with_modules_no_module_thresholds_with_bs], 9, 4, [], False, True),
     ("11", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, {}, {}, changed_files, [comment_more_files_single_detailed_instruction_no_modules], 9, 0, [], False, False),
     ("12", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, {}, {}, changed_files, [comment_more_files_single_detailed_instruction_no_modules_with_bs], 9, 0, [], False, True),
-    ("13", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, [comment_more_files_single_detailed_instruction_with_modules], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, False),
-    ("14", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, [comment_more_files_single_detailed_instruction_with_modules_with_bs], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, True),
+    ("13", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, [comment_more_files_single_detailed_instruction_with_modules], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, False),
+    ("14", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, [comment_more_files_single_detailed_instruction_with_modules_with_bs], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, True),
     ("15", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, {}, changed_files, [comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed], 9, 4, [], False, False),
     ("16", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, {}, changed_files, [comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed_with_bs], 9, 4, [], False, True),
     ("17", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, {}, changed_files, [comment_more_files_single_detailed_instruction_with_modules_no_module_thresholds_skip_changed], 9, 4, [], True, False),
@@ -1966,8 +1966,8 @@ more_source_files_scenarios = [
     ("30", CommentModeEnum.MULTI, SensitivityEnum.SUMMARY, modules, {}, changed_files, comment_multi_minimalist_instruction_with_bs, 9, 0, [], False, True),
     ("31", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, {}, {}, changed_files, comment_multi_detailed_instruction_no_modules, 9, 0, [], False, False),
     ("32", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, {}, {}, changed_files, comment_multi_detailed_instruction_no_modules_with_bs, 9, 0, [], False, True),
-    ("33", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_multi_detailed_instruction_with_modules, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, False),
-    ("34", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_multi_detailed_instruction_with_modules_with_bs, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, True),
+    ("33", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_multi_detailed_instruction_with_modules, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, False),
+    ("34", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_multi_detailed_instruction_with_modules_with_bs, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, True),
     ("35", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_multi_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed, 9, 0, [], False, False),
     ("36", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_multi_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed_with_bs, 9, 0, [], False, True),
     ("37", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_multi_detailed_instruction_with_modules_no_module_thresholds_skip_changed, 9, 0, [], True, False),
@@ -1978,25 +1978,25 @@ more_source_files_scenarios = [
     ("42", CommentModeEnum.MODULE, SensitivityEnum.SUMMARY, modules, {}, changed_files, comment_module_minimalist_instruction_with_bs_summary, 9, 4, [], False, True),
     ("43", CommentModeEnum.MODULE, SensitivityEnum.SUMMARY, modules, modules_thresholds, changed_files, comment_module_summary_instruction_with_modules, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0."], False, False),
     ("44", CommentModeEnum.MODULE, SensitivityEnum.SUMMARY, modules, modules_thresholds, changed_files, comment_module_summary_instruction_with_modules_with_bs, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0."], False, True),
-    ("45", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_module_detail_instruction_with_modules, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, False),
-    ("46", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_module_detailed_instruction_with_modules_with_bs, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], False, True),
+    ("45", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_module_detail_instruction_with_modules, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, False),
+    ("46", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds, changed_files, comment_module_detailed_instruction_with_modules_with_bs, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], False, True),
     ("47", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_module_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed, 9, 4, [], False, False),
     ("48", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_module_detailed_instruction_with_modules_no_module_thresholds_not_skip_changed_with_bs, 9, 4, [], False, True),
     ("49", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_changed, 9, 4, [], True, False),
     ("50", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, {}, changed_files, comment_module_detailed_instruction_with_modules_no_module_thresholds_skip_changed_with_bs, 9, 4, [], True, True),
     # failing module and reports without changed files
-    ("51", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
-    ("52", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, [comment_more_files_single_detailed_instruction_with_modules_with_bs_fail_module], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
-    ("53", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, comment_multi_detailed_instruction_with_modules_with_bs_fail_module, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
+    ("51", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
+    ("52", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, [comment_more_files_single_detailed_instruction_with_modules_with_bs_fail_module], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
+    ("53", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules, modules_thresholds_100, changed_files, comment_multi_detailed_instruction_with_modules_with_bs_fail_module, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
     # failing report in passing module
-    ("54", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds_89, changed_files_large_only, comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module_fail_report, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0.", "Report 'user-info: Implementation Module Report' overall coverage 88.0 is below the threshold 89.0."], True, True),
+    ("54", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules, modules_thresholds_89, changed_files_large_only, comment_module_detailed_instruction_with_modules_with_bs_fail_non_changed_module_fail_report, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5.", "Report 'user-info: Implementation Module Report' overall coverage 88.0 is below the threshold 89.0."], True, True),
     # only partial set of modules
     ("55", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules_partial_definition_1_report, modules_thresholds_100_partial_definition_1_report, changed_files, [comment_more_files_single_detailed_instruction_with_partial_modules_1], 9, 4, ["Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
     ("56", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules_partial_definition_1_report, modules_thresholds_100_partial_definition_1_report, changed_files, comment_multi_detailed_instruction_with_modules_report_1, 9, 0, ["Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
     ("57", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules_partial_definition_1_report, modules_thresholds_100_partial_definition_1_report, changed_files, comment_module_detailed_instruction_with_modules_with_bs_report_1, 9, 4, ["Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
-    ("58", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, [comment_more_files_single_detailed_instruction_with_partial_modules_2], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
-    ("59", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, comment_multi_detailed_instruction_with_modules_with_bs_partial_modules_2, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
-    ("60", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_2, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 91.0."], True, True),
+    ("58", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, [comment_more_files_single_detailed_instruction_with_partial_modules_2], 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
+    ("59", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, comment_multi_detailed_instruction_with_modules_with_bs_partial_modules_2, 9, 0, ["Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
+    ("60", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules_partial_definition_2_reports, modules_thresholds_100_partial_definition_2_reports, changed_files, comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_2, 9, 4, ["Module 'module_large' changed files coverage 90.0 is below the threshold 91.0.", "Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Large Report' changed files coverage 90.0 is below the threshold 91.0.", "Report 'Module Large Report' changed file 'com/example/module_large/BigClass.java' coverage 90.0 is below the threshold 90.5."], True, True),
     ("61", CommentModeEnum.SINGLE, SensitivityEnum.DETAIL, modules_partial_definition_3_reports, modules_thresholds_100_partial_definition_3_reports, changed_files, [comment_more_files_single_detailed_instruction_with_partial_modules_3], 9, 3, ["Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
     ("62", CommentModeEnum.MULTI, SensitivityEnum.DETAIL, modules_partial_definition_3_reports, modules_thresholds_100_partial_definition_3_reports, changed_files, comment_multi_detailed_instruction_with_modules_with_bs_partial_modules_3, 9, 0, ["Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
     ("63", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules_partial_definition_3_reports, modules_thresholds_100_partial_definition_3_reports, changed_files, comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_3, 9, 3, ["Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
@@ -2015,6 +2015,7 @@ def test_successful_more_source_files(jacoco_report, id, mode, template, modules
         mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["tests/data_baseline/**/*.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_overall", return_value=75.0)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_changed_files", return_value=80.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_per_changed_file", return_value=65.0)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value=modules)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules_thresholds", return_value=modules_thresholds)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="MoranaApps/jacoco-report")
@@ -2254,6 +2255,7 @@ def test_violations(jacoco_report, id, mode, template, modules, modules_threshol
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_paths", return_value=["tests/data/test_project/**/jacoco.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_overall", return_value=100.0)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_changed_files", return_value=100.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_min_coverage_per_changed_file", return_value=100.0)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value=modules)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules_thresholds", return_value=modules_thresholds)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="MoranaApps/jacoco-report")


### PR DESCRIPTION
Release Notes:
- Introduced a new coverage threshold level to enforce a minimum coverage percentage for changed files. This level is applied to changed files compared to the global one in the report module.

Closes #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new coverage threshold option to enforce a minimum coverage percentage for each changed file individually.
  - Documentation and usage examples updated to reflect the new per-file coverage threshold option.

- **Bug Fixes**
  - Coverage tables and comments now accurately display and apply the per-changed-file threshold.

- **Tests**
  - Added and updated tests to validate the new per-changed-file coverage threshold and its integration.

- **Documentation**
  - Improved and clarified documentation for all coverage threshold options and usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->