### PR TITLE
#67 - Rename the input skip-not-changed to skip-unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
 | `comment-mode`                  | Mode of the comment (`single` for one comment, `multi` for comments per jacoco.xml file, <br> `module` for comment per each module).                                                                                    | No                              | `single`                                                                                              |
 | `modules`                       | List of modules and their unique paths (e.g., `management: context/management`).<br>Required when `comment-mode` set to `module`. <br> Optional when `comment-mode` set to `single`.                                    | If `comment-mode` is `module`   | ''                                                                                                      |
 | `modules-thresholds`            | List of modules and their coverage thresholds (e.g., `core: 80`). Optional when `comment-mode` set to `module`.                                                                                                         | No                              | ''                                                                                                      |
-| `skip-not-changed`              | If enabled (true), filters JaCoCo-related comments to show only relevant changes.<br>It removes unchanged lines from the modules table and skips comments for unmodified modules and reports, <br> reducing noise in PRs. | No                              | false                                                                                                 |
+| `skip-unchanged`                | If enabled (true), filters JaCoCo-related comments to show only relevant changes.<br>It removes unchanged lines from the modules table and skips comments for unmodified modules and reports, <br> reducing noise in PRs. | No                              | false                                                                                                 |
 | `baseline-paths`                | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.<br>Paths have to be valid for modules if used.                                                                                      | No                              | ''                                                                                                    |
 | `update-comment`                | If enabled (true), ensures the action updates an existing comment with the latest coverage <br> data instead of creating a new comment. Prevents comment clutter in pull requests.                                      | No                              | true                                                                                                  |
 | `pass-symbol`                   | Symbol displayed next to passing checks in the pull request comments (e.g., ✅, **Passed**).                                                                                                                             | No                              | ✅                                                                                                     |
@@ -103,7 +103,7 @@ threshold.
   - [Minimal Sensitivity](#minimal-sensitivity)
   - [Summary Sensitivity](#summary-sensitivity)
   - [Detailed Sensitivity](#detailed-sensitivity)
-- [Customizing the Skip Not Changed Option and Update Comment](#customizing-the-skip-not-changed-option-and-update-comment)
+- [Customizing the Skip Unchanged Option and Update Comment](#customizing-the-skip-unchanged-option-and-update-comment)
 - [Customizing the Baseline Paths](#customizing-the-baseline-paths)
 - [Customizing the Symbols and Metric Type](#customizing-the-symbols-and-metric-type)
 - [Customizing the Debug Mode](#customizing-the-debug-mode)
@@ -341,9 +341,9 @@ coverage.
 > - The report table is always visible. When `modules` and `modules-thresholds` are defined, the module's thresholds
 > are used; otherwise, the minimal thresholds are used.
 
-#### Customizing the Skip Not Changed Option and Update Comment
+#### Customizing the Skip Unchanged Option and Update Comment
 
-The `skip-not-changed` input, when set to true, optimizes JaCoCo-related comments by focusing only on relevant changes
+The `skip-unchanged` input, when set to true, optimizes JaCoCo-related comments by focusing only on relevant changes
 in the pull request. It removes unchanged lines from the modules table and reduces the number of generated comments by
 skipping entire modules and reports with no modified files.
 
@@ -357,7 +357,7 @@ The comment is identified by the title.
   with:
     token: '${{ secrets.TOKEN }}'
     paths: **/jacoco/**/*.xml
-    skip-not-changed: true  # Skip commenting for unchanged files
+    skip-unchanged: true  # Skip commenting for unchanged files
     update-comment: true  # Update the existing comment with the latest coverage data
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: 'Identify the modules and their thresholds.'
     required: false
     default: ''
-  skip-not-changed:
+  skip-unchanged:
     description: 'Reduce module table and comments to ones with changed files in PR.'
     required: false
     default: 'false'
@@ -160,7 +160,7 @@ runs:
         echo "${{ inputs.modules-thresholds }}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
     
-        echo "INPUT_SKIP_NOT_CHANGED=${{ inputs.skip-not-changed }}" >> $GITHUB_ENV
+        echo "INPUT_SKIP_UNCHANGED=${{ inputs.skip-unchanged }}" >> $GITHUB_ENV
         
         echo "INPUT_BASELINE_PATHS<<EOF" >> $GITHUB_ENV
         echo "${{ inputs.baseline-paths }}" >> $GITHUB_ENV

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -18,7 +18,7 @@ from jacoco_report.utils.constants import (
     COMMENT_MODE,
     MODULES,
     MODULES_THRESHOLDS,
-    SKIP_NOT_CHANGED,
+    SKIP_UNCHANGED,
     UPDATE_COMMENT,
     PASS_SYMBOL,
     FAIL_SYMBOL,
@@ -231,11 +231,11 @@ class ActionInputs:
         return parse_module_thresholds(raw_input)
 
     @staticmethod
-    def get_skip_not_changed() -> bool:
+    def get_skip_unchanged() -> bool:
         """
-        Get the skip not changed from the action inputs.
+        Get the skip unchanged from the action inputs.
         """
-        return get_action_input(SKIP_NOT_CHANGED, "false") == "true"
+        return get_action_input(SKIP_UNCHANGED, "false") == "true"
 
     @staticmethod
     def get_update_comment() -> bool:
@@ -511,9 +511,9 @@ class ActionInputs:
                 for module_threshold in f_modules_thresholds:
                     errors.extend(ActionInputs.validate_module_threshold(module_threshold))
 
-        skip_not_changed = ActionInputs.get_skip_not_changed()
-        if not isinstance(skip_not_changed, bool):
-            errors.append("'skip-not-changed' must be a boolean.")
+        skip_unchanged = ActionInputs.get_skip_unchanged()
+        if not isinstance(skip_unchanged, bool):
+            errors.append("'skip-unchanged' must be a boolean.")
 
         update_comment = ActionInputs.get_update_comment()
         if not isinstance(update_comment, bool):
@@ -554,7 +554,7 @@ class ActionInputs:
             f"Title: {ActionInputs.get_title()}\n"
             f"Comment mode: {ActionInputs.get_comment_mode()}\n"
             "\n"
-            f"Skip not changed: {ActionInputs.get_skip_not_changed()}\n"
+            f"Skip unchanged: {ActionInputs.get_skip_unchanged()}\n"
             f"Update comment: {ActionInputs.get_update_comment()}\n"
             f"Fail on threshold: {ActionInputs.get_fail_on_threshold()}\n"
             f"Debug logging enabled: {ActionInputs.get_debug()}"

--- a/jacoco_report/generator/module_pr_comment_generator.py
+++ b/jacoco_report/generator/module_pr_comment_generator.py
@@ -55,7 +55,7 @@ class ModulePRCommentGenerator(MultiPRCommentGenerator):
             inner_reports_passed = self._check_inner_reports_passed(evaluated_module_coverage)
 
             if (
-                ActionInputs.get_skip_not_changed()
+                ActionInputs.get_skip_unchanged()
                 and len(changed_lines) == 0
                 and evaluated_module_coverage.overall_passed
                 and evaluated_module_coverage.sum_changed_files_passed

--- a/jacoco_report/generator/multi_pr_comment_generator.py
+++ b/jacoco_report/generator/multi_pr_comment_generator.py
@@ -64,7 +64,7 @@ class MultiPRCommentGenerator(PRCommentGenerator):
             title = body = f"**{ActionInputs.get_title(evaluated_coverage_report.name)}**"
 
             if (
-                ActionInputs.get_skip_not_changed()
+                ActionInputs.get_skip_unchanged()
                 and len(evaluated_coverage_report.changed_files_passed) == 0
                 and evaluated_coverage_report.overall_passed
                 and evaluated_coverage_report.sum_changed_files_passed

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -151,7 +151,7 @@ class PRCommentGenerator:
     # pylint: disable=unused-argument
     def _generate_reports_table__skip(self, evaluated_report: EvaluatedReportCoverage, **kwargs) -> bool:
         if (
-            ActionInputs.get_skip_not_changed()
+            ActionInputs.get_skip_unchanged()
             and evaluated_report.name not in self.changed_modules
             and evaluated_report.overall_passed
             and evaluated_report.sum_changed_files_passed
@@ -279,7 +279,7 @@ class PRCommentGenerator:
     # pylint: disable=unused-argument
     def _generate_modules_table__skip(self, evaluated_report: EvaluatedReportCoverage, **kwargs) -> bool:
         if (
-            ActionInputs.get_skip_not_changed()
+            ActionInputs.get_skip_unchanged()
             and evaluated_report.name not in self.changed_modules
             and evaluated_report.overall_passed
             and evaluated_report.sum_changed_files_passed

--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -80,7 +80,7 @@ class JaCoCoReport:
         for report_path in input_report_paths_to_analyse:
             report_files_coverage.append(rfc := parser.parse(report_path))
 
-            if ActionInputs.get_skip_not_changed() and rfc.module_name is not None and rfc.changed_files_coverage != {}:
+            if ActionInputs.get_skip_unchanged() and rfc.module_name is not None and rfc.changed_files_coverage != {}:
                 changed_modules.add(rfc.module_name)  # note module with changed files
 
         # get baseline files for comparison

--- a/jacoco_report/utils/constants.py
+++ b/jacoco_report/utils/constants.py
@@ -20,7 +20,7 @@ COMMENT_MODE = "comment-mode"
 MODULES = "modules"
 MODULES_THRESHOLDS = "modules-thresholds"
 
-SKIP_NOT_CHANGED = "skip-not-changed"
+SKIP_UNCHANGED = "skip-unchanged"
 UPDATE_COMMENT = "update-comment"
 PASS_SYMBOL = "pass-symbol"
 FAIL_SYMBOL = "fail-symbol"

--- a/tests/generator/test_multi_pr_comment_generator.py
+++ b/tests/generator/test_multi_pr_comment_generator.py
@@ -37,7 +37,7 @@ def test_no_changed_files_in_reports(mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=True)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_title", return_value="Report Title")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=None)
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
 
     # Create a mock GitHub instance
     mock_gh = mocker.Mock(spec=GitHub)

--- a/tests/generator/test_pr_comment_generator.py
+++ b/tests/generator/test_pr_comment_generator.py
@@ -53,7 +53,7 @@ def test_get_modules_table(pr_comment_generator):
 def test_get_modules_table_with_baseline_with_modules(pr_comment_generator, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
     mocker.patch("jacoco_report.generator.pr_comment_generator.PRCommentGenerator._calculate_baseline_module_diffs", return_value=(1.1, 2.0))
 
     pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0, 80.0)
@@ -71,7 +71,7 @@ def test_get_modules_table_with_baseline_with_modules(pr_comment_generator, mock
 def test_generate_modules_table_with_baseline(pr_comment_generator, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=True)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=True)
     mocker.patch("jacoco_report.generator.pr_comment_generator.PRCommentGenerator._calculate_baseline_module_diffs", return_value=(1.1, 2.0))
 
     pr_comment_generator.evaluator._modules["test"] = Module("test", "path",85.2, 80.0, 80.0)
@@ -136,7 +136,7 @@ def test_generate_changed_files_table_with_baseline(pr_comment_generator, mocker
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
     mocker.patch("hashlib.sha256", return_value=mocker.Mock(hexdigest=lambda: "fakehash"))
 
     pr_comment_generator.github_repository = "fake_repo"
@@ -176,7 +176,7 @@ def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
     mocker.patch("hashlib.sha256", return_value=mocker.Mock(hexdigest=lambda: "fakehash"))
 
     pr_comment_generator.github_repository = "fake_repo"
@@ -216,7 +216,7 @@ def test_generate_changed_files_table_with_baseline_no_changed_file(pr_comment_g
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
     mocker.patch("hashlib.sha256", return_value=mocker.Mock(hexdigest=lambda: "fakehash"))
 
     pr_comment_generator.github_repository = "fake_repo"

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -19,7 +19,7 @@ success_case = {
     "get_comment_mode": "single",
     "get_modules": "module-a:context/module_a,module-b:module_b",
     "get_modules_thresholds": "module-a:80**,module-b:*70*",
-    "get_skip_not_changed": True,
+    "get_skip_unchanged": True,
     "get_update_comment": True,
     "get_pass_symbol": "**Passed**",
     "get_fail_symbol": "❗",
@@ -75,8 +75,8 @@ failure_cases = [
     ("get_modules_thresholds", "module-a:80**,module-b:**True", "'module-threshold' changed per file value 'True' must be a float or None."),
     ("get_modules_thresholds", "module-a:80**,module-b:*80*:9", "'module-threshold':'module-b:*80*:9' must be in the format 'module:threshold'."),
     ("get_modules_thresholds", "module-a:80**,module-b:*80*:9", "'module-threshold':'module-b:*80*:9' must be in the format 'module:threshold'."),
-    ("get_skip_not_changed", "", "'skip-not-changed' must be a boolean."),
-    ("get_skip_not_changed", 1, "'skip-not-changed' must be a boolean."),
+    ("get_skip_unchanged", "", "'skip-unchanged' must be a boolean."),
+    ("get_skip_unchanged", 1, "'skip-unchanged' must be a boolean."),
     ("get_update_comment", "", "'update-comment' must be a boolean."),
     ("get_update_comment", 1, "'update-comment' must be a boolean."),
     ("get_pass_symbol", "", "'pass-symbol' must be a non-empty string and have a length from 1."),
@@ -301,14 +301,14 @@ def test_get_modules_thresholds_raw(mocker):
     assert "module-a:80*,module-b:  *70" == ActionInputs.get_modules_thresholds(raw=True)
 
 
-def test_get_skip_not_changed_true(mocker):
+def test_get_skip_unchanged_true(mocker):
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value="true")
-    assert True == ActionInputs.get_skip_not_changed()
+    assert True == ActionInputs.get_skip_unchanged()
 
 
-def test_get_skip_not_changed_false(mocker):
+def test_get_skip_unchanged_false(mocker):
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value="false")
-    assert False == ActionInputs.get_skip_not_changed()
+    assert False == ActionInputs.get_skip_unchanged()
 
 
 def test_get_update_comment_true(mocker):

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -303,12 +303,12 @@ def test_get_modules_thresholds_raw(mocker):
 
 def test_get_skip_unchanged_true(mocker):
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value="true")
-    assert True == ActionInputs.get_skip_unchanged()
+    assert ActionInputs.get_skip_unchanged()
 
 
 def test_get_skip_unchanged_false(mocker):
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value="false")
-    assert False == ActionInputs.get_skip_unchanged()
+    assert not ActionInputs.get_skip_unchanged()
 
 
 def test_get_update_comment_true(mocker):

--- a/tests/test_jacoco_report.py
+++ b/tests/test_jacoco_report.py
@@ -2002,8 +2002,8 @@ more_source_files_scenarios = [
     ("63", CommentModeEnum.MODULE, SensitivityEnum.DETAIL, modules_partial_definition_3_reports, modules_thresholds_100_partial_definition_3_reports, changed_files, comment_module_detailed_instruction_with_modules_with_bs_partial_modules_report_3, 9, 3, ["Module 'module small' overall coverage 97.0 is below the threshold 100.0.", "Report 'Module Small Report' overall coverage 97.0 is below the threshold 100.0."], True, True),
 ]
 
-@pytest.mark.parametrize("id, mode, template, modules, modules_thresholds, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_modules, violations, skip_not_changed, use_baseline", more_source_files_scenarios)
-def test_successful_more_source_files(jacoco_report, id, mode, template, modules, modules_thresholds, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_modules, violations, skip_not_changed, use_baseline, mocker):
+@pytest.mark.parametrize("id, mode, template, modules, modules_thresholds, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_modules, violations, skip_unchanged, use_baseline", more_source_files_scenarios)
+def test_successful_more_source_files(jacoco_report, id, mode, template, modules, modules_thresholds, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_modules, violations, skip_unchanged, use_baseline, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_mode", return_value=mode)
@@ -2019,7 +2019,7 @@ def test_successful_more_source_files(jacoco_report, id, mode, template, modules
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value=modules)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules_thresholds", return_value=modules_thresholds)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="MoranaApps/jacoco-report")
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=skip_not_changed)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=skip_unchanged)
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=changed_files)
 
@@ -2259,7 +2259,7 @@ def test_violations(jacoco_report, id, mode, template, modules, modules_threshol
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value=modules)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules_thresholds", return_value=modules_thresholds)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="MoranaApps/jacoco-report")
-    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_not_changed", return_value=True)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=True)
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=changed_files)
 


### PR DESCRIPTION
Release Notes:
- Input input `skip-not-changed` renamed to `skip-unchanged`.

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to consistently use the term `skip-unchanged` instead of `skip-not-changed` for the input parameter.
- **Refactor**
  - Renamed configuration input and related references from `skip-not-changed` to `skip-unchanged` across the user interface and internal logic.
- **Tests**
  - Updated test cases and parameter names to reflect the new `skip-unchanged` naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->