### PR TITLE
#91 - Fail action run when no jacoco.xml file found

### DIFF
--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -61,7 +61,8 @@ class JaCoCoReport:
 
         # skip when not jacoco xml files found
         if len(input_report_paths_to_analyse) == 0:
-            logger.warning("No JaCoCo xml file found. No comment will be generated.")
+            logger.error("No input JaCoCo xml file found. No comment will be generated.")
+            self.violations.append("No input JaCoCo xml file found.")
             return
 
         # get changed files in PR

--- a/tests/test_jacoco_report.py
+++ b/tests/test_jacoco_report.py
@@ -1887,11 +1887,12 @@ def test_run_no_jacoco_xml_files(jacoco_report, caplog, mocker):
     mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[])
     mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         jacoco_report.run()
         assert jacoco_report.total_overall_coverage == 0.0
         assert jacoco_report.total_changed_files_coverage == 0.0
-        assert "No JaCoCo xml file found. No comment will be generated." in caplog.text
+        assert "No input JaCoCo xml file found. No comment will be generated." in caplog.text
+        assert jacoco_report.violations[0] == "No input JaCoCo xml file found."
         mock_add_comment.assert_not_called()
 
 def test_run_successful_empty_no_baseline(jacoco_report, mocker):


### PR DESCRIPTION
Release Notes:
- Improved error handling when no JaCoCo XML report files are found by logging an error and recording a violation 

Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when no JaCoCo XML report files are found by logging an error and recording a violation message.
- **Tests**
	- Updated tests to reflect changes in error messaging and logging behavior for missing JaCoCo XML files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->