### PR TITLE
#90 - Remove comments when present in path input

### DIFF
--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -172,15 +172,12 @@ class ActionInputs:
 
         if len(mods) > 0:
             for mod in mods.split(split_by):
-                # detect presence of '#' char - user commented out the line
-                if "#" in mod:
+                cleaned_mod = ActionInputs.__clean_from_comment(mod)
+                if len(cleaned_mod) == 0:
                     continue
 
-                # format string, clean up, ...
-                formatted_mod = mod.strip()
-
                 # create a dictionary record from formatted string
-                key, value = formatted_mod.split(":")
+                key, value = cleaned_mod.split(":")
                 d[key] = value.strip()
 
         return d
@@ -199,14 +196,13 @@ class ActionInputs:
             split_by: str = "," if "," in received else "\n"
             mts: list[str] = received.split(split_by)
             for mt in mts:
-                # detect presence of '#' char - user commented out the line
-                if "#" in mt.lstrip():
+                # format string, clean up, ...
+                cleaned_mt = ActionInputs.__clean_from_comment(mt)
+
+                if len(cleaned_mt) == 0:
                     continue
 
-                # format string, clean up, ...
-                formatted_mt = mt.strip()
-
-                name, values = formatted_mt.split(":")
+                name, values = cleaned_mt.split(":")
                 f_name = name.strip()
                 f_values = values.strip()
                 parts = f_values.split("*")
@@ -337,10 +333,6 @@ class ActionInputs:
         Returns:
             list: A list of errors if any.
         """
-        # Check if the input is a non-empty string
-        if not input_module_threshold:
-            return ["'module-threshold' must be a non-empty string."]
-
         # Check if the module is in the format 'module:threshold'
         if ":" not in input_module_threshold or input_module_threshold.count(":") > 1:
             return [f"'module-threshold':'{input_module_threshold}' must be in the format 'module:threshold'."]
@@ -509,7 +501,9 @@ class ActionInputs:
                 split_by: str = "," if "," in modules_thresholds else "\n"  # type: ignore[no-redef]
                 f_modules_thresholds = modules_thresholds.split(split_by)
                 for module_threshold in f_modules_thresholds:
-                    errors.extend(ActionInputs.validate_module_threshold(module_threshold))
+                    cleaned_module_threshold = ActionInputs.__clean_from_comment(module_threshold)
+                    if len(cleaned_module_threshold) > 0:
+                        errors.extend(ActionInputs.validate_module_threshold(cleaned_module_threshold))
 
         skip_unchanged = ActionInputs.get_skip_unchanged()
         if not isinstance(skip_unchanged, bool):
@@ -597,13 +591,24 @@ class ActionInputs:
 
         res: list[str] = []
         for path in paths.splitlines():
-            # detect presence of '#' char - user commented out the line
-            if path.strip().startswith("#"):
+            cleaned_path = ActionInputs.__clean_from_comment(path)
+            if len(cleaned_path) == 0:
                 continue
-
-            # format string, clean up, ...
-            formatted_path = path.strip()
-            if len(formatted_path) > 0:
-                res.append(formatted_path.strip())
+            else:
+                res.append(cleaned_path)
 
         return res
+
+    @staticmethod
+    def __clean_from_comment(input_string: str) -> str:
+        """
+        Clean the input string from comments.
+        Examples:
+            "path/to/file # this is a comment" -> "path/to/file"
+            "# this is a comment" -> ""
+            "   # this is a comment" -> ""
+            "   path/to/file # this is a comment" -> "path/to/file"
+        """
+        if "#" in input_string:
+            return input_string.split("#")[0].strip()
+        return input_string.strip()

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -64,7 +64,6 @@ failure_cases = [
     ("get_modules_thresholds", 1, "'modules-thresholds' must be a string or not defined."),
     ("get_modules_thresholds", "ab", "'modules-thresholds' must be a list of strings in format 'module:overall*changed'."),
     ("get_modules_thresholds", "abcd", "'modules-thresholds' must be a list of strings in format 'module:overall*changed'."),
-    ("get_modules_thresholds", "module-a: 80**,", "'module-threshold' must be a non-empty string."),
     ("get_modules_thresholds", "module-a: 80*", "'module-threshold':'80*' must contain two '*' to split overall, changed files and changed per file threshold."),
     ("get_modules_thresholds", "module-a:80**,module-b", "'module-threshold':'module-b' must be in the format 'module:threshold'."),
     ("get_modules_thresholds", "module-a:80**,:80.0**", "Module threshold with value:'80.0**' must have a non-empty name."),
@@ -145,7 +144,7 @@ def test_get_paths(mocker):
 def test_get_paths_with_comment(mocker):
     data = f"""
     test/path1
-    test/path2
+    test/path2      # another comment
     # test/path3    
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=data)
@@ -178,7 +177,7 @@ def test_get_exclude_paths(mocker):
 def test_get_exclude_paths_with_comment(mocker):
     data = f"""
     test/path1
-    test/path2
+    test/path2      # another comment
     #test/path3    
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=data)
@@ -256,7 +255,7 @@ def test_get_modules_with_commented_line(mocker):
     input_data = """module-a: context/module_a
     # module-b: module_b
     # module-c: context/module_c
-    module-d: context/module_d
+    module-d: context/module_d      # another comment
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=input_data)
     assert {"module-a": "context/module_a", "module-d": "context/module_d"} == ActionInputs.get_modules()
@@ -291,9 +290,10 @@ def test_get_modules_thresholds_with_commented_line(mocker):
     module-b: *70*
     #module-c: 90**
     # module-d: *100*
+    module-e: *100*     # another comment 
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=input_data)
-    assert {"module-a": (80.0, 0.0, 0.0), "module-b": (0.0, 70.0, 0.0)} == ActionInputs.get_modules_thresholds()
+    assert {"module-a": (80.0, 0.0, 0.0), "module-b": (0.0, 70.0, 0.0), "module-e": (0.0, 100.0, 0.0)} == ActionInputs.get_modules_thresholds()
 
 
 def test_get_modules_thresholds_raw(mocker):
@@ -363,7 +363,7 @@ def test_get_baseline_paths(mocker):
 def test_get_baseline_paths_with_comment(mocker):
     data = f"""
     test/path1
-    test/path2
+    test/path2      # another comment
     #test/path3
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=data)

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -293,7 +293,7 @@ def test_get_modules_thresholds_with_commented_line(mocker):
     module-e: *100*     # another comment 
     """
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value=input_data)
-    assert {"module-a": (80.0, 0.0, 0.0), "module-b": (0.0, 70.0, 0.0), "module-e": (0.0, 100.0, 0.0)} == ActionInputs.get_modules_thresholds()
+    assert ActionInputs.get_modules_thresholds() == {"module-a": (80.0, 0.0, 0.0), "module-b": (0.0, 70.0, 0.0), "module-e": (0.0, 100.0, 0.0)}
 
 
 def test_get_modules_thresholds_raw(mocker):


### PR DESCRIPTION
Release Notes:
- Improved handling of input strings to consistently ignore inline and trailing comments during parsing.

Closes #90 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage to verify correct parsing of inputs with inline comments, ensuring comments do not affect the results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->