### PR TITLE
@118 - Bug: Fails on not present data

### DIFF
--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -314,6 +314,11 @@ class CoverageEvaluator:
         ):
             evaluated_coverage_report.avg_changed_files_coverage_reached = 0.0
             evaluated_coverage_report.avg_changed_files_passed = True
+
+            # evaluate the changed files
+            for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
+                evaluated_coverage_report.changed_files_passed[key] = True
+
         else:
             evaluated_coverage_report.avg_changed_files_coverage_reached = round(
                 sum(evaluated_coverage_report.changed_files_coverage_reached.values())

--- a/tests/test_jacoco_report.py
+++ b/tests/test_jacoco_report.py
@@ -2273,3 +2273,47 @@ def test_violations(jacoco_report, id, level, modules, modules_thresholds, chang
     assert len(jacoco_report.violations) == len(violations)
     for violation in violations:
         assert violation in actual_merger_violations
+
+def test_filtered_out_all_from_changed_file(jacoco_report, mocker):
+    changed_files = [
+        'com/example/ExampleClass.java'
+    ]
+
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value=CommentLevelEnum.FULL)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_paths", return_value=["tests/data/module_d/**/jacoco*.xml"])
+    # mocker.patch("jacoco_report.action_inputs.ActionInputs.get_paths", return_value=["data/module_d/**/jacoco*.xml"])
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_overall_threshold", return_value=100.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_changed_files_average_threshold", return_value=100.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_changed_file_threshold", return_value=100.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={})
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules_thresholds", return_value={})
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="MoranaApps/jacoco-report")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=False)
+    mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
+    mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=changed_files)
+
+    mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)
+
+    jacoco_report.run()
+
+    print("hello")
+
+    for item in mock_add_comment.call_args_list:
+        print(item)
+
+    print("bye")
+
+
+    # for comment in mock_add_comment.call_args_list:
+    #     print(f"\ncomment: \n{comment[0][1]}")
+
+    # assert mock_add_comment.call_count == len(expected_comments)
+
+    # if len(expected_comments):
+    #     mock_add_comment.assert_called_once_with(35, expected_comments[0])
+
+    # Parse the JSON strings
+    # dict_evaluated_coverage_reports: dict = json.loads(jacoco_report.evaluated_coverage_reports)
+    # dict_evaluated_coverage_modules: dict = json.loads(jacoco_report.evaluated_coverage_modules)


### PR DESCRIPTION
Release Notes:
- Added default pass of changed file when it was filtered out.

{PR Summary}

Closes #issue_number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures per-file pass statuses are recorded when changed files have 0 covered and 0 missed lines, preventing empty per-file results and improving consistency in per-file violation reporting.

* **Tests**
  * Added a test covering scenarios where all lines in a changed file are filtered out under strict thresholds, improving confidence in changed-file filtering and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->