### PR TITLE
@118 - Bug: Fails on not present data

### DIFF
--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -353,6 +353,11 @@ class CoverageEvaluator:
         ):
             evaluated_coverage_report.avg_changed_files_coverage_reached = 0.0
             evaluated_coverage_report.avg_changed_files_passed = True
+
+            # evaluate the changed files
+            for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
+                evaluated_coverage_report.changed_files_passed[key] = True
+
         else:
             evaluated_coverage_report.avg_changed_files_coverage_reached = round(
                 sum(evaluated_coverage_report.changed_files_coverage_reached.values())

--- a/tests/data/module_d/target/jacoco_one_source_file_filtered_out_all_from_changed_class.xml
+++ b/tests/data/module_d/target/jacoco_one_source_file_filtered_out_all_from_changed_class.xml
@@ -1,0 +1,13 @@
+<report name="Example Report">
+    <sessioninfo id="example-session" start="1609459200000" dump="1609459200000"/>
+    <package name="com/example">
+        <class name="com/example/ExampleClass" sourcefilename="ExampleClass.java"/>
+        <sourcefile name="ExampleClass.java"/>
+    </package>
+    <counter type="INSTRUCTION" missed="10" covered="90"/>
+    <counter type="BRANCH" missed="1" covered="3"/>
+    <counter type="LINE" missed="2" covered="8"/>
+    <counter type="COMPLEXITY" missed="1" covered="3"/>
+    <counter type="METHOD" missed="0" covered="1"/>
+    <counter type="CLASS" missed="0" covered="1"/>
+</report>


### PR DESCRIPTION
Release Notes:
- Added default pass of changed file when it was filtered out.
- Fix for support branch and master one.

{PR Summary}



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected per-file status reporting when changed-file coverage is zero or files are filtered out, ensuring changed files are listed with appropriate pass status in PR comments.

* **Tests**
  * Added test covering the scenario where a changed file is filtered out, validating PR comment output (overall, changed-files, and per-file sections).
  * Included a new JaCoCo report fixture for a single-source-file module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->