### PR TITLE
Chore/add copilot ai tooling files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,8 @@
       "Bash(pip install *)",
       "Bash(git fetch *)",
       "Bash(git checkout *)",
-      "Bash(git branch *)"
+      "Bash(git branch *)",
+      "Bash(gh auth *)"
     ]
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,95 @@
+# Copilot Instructions — jacoco-report
+
+## Purpose
+
+This file defines the coding contract for all AI-assisted sessions (Copilot, Claude Code) on this project.
+Rules use constraint words: **Must** / **Must not** / **Prefer** / **Avoid**.
+
+---
+
+## TDD Workflow (highest priority)
+
+1. Before writing any code, create or update `SPEC.md` in the relevant package directory.
+2. Propose the full test-case table (name · one-line intent · input summary · expected output) and wait for confirmation.
+3. Write all failing tests first (red), then implement until green.
+4. After all tests pass, update `SPEC.md` with the confirmed test-case table.
+
+Must not write implementation code before the test-case table is approved.
+
+---
+
+## Output Discipline
+
+- Responses Must be concise — prefer ≤10 lines of prose outside code blocks.
+- Must end each change with three lines: _What changed_ / _Why_ / _How to verify_.
+- Must not paste large unchanged code blocks; show only the diff-relevant lines.
+- PR body Must be treated as a changelog. Append new entries under `## Update [YYYY-MM-DD]` with the commit hash. Never rewrite the entire body.
+
+---
+
+## Language Rules
+
+- Python 3.12+ syntax. Must use type hints on all public functions and classes.
+- Must use `logging` — never `print()`.
+- Must use lazy `%` formatting in all log calls: `logger.info("value: %s", val)`.
+- Must not use f-strings or format strings inside logging calls.
+- Prefer f-strings for all other string templates.
+- Imports Must be at the top of the file, grouped: stdlib → third-party → local.
+
+---
+
+## Docstrings
+
+- Must include a short one-line summary.
+- Structured sections where applicable: `Parameters`, `Returns`, `Raises`.
+- Must not include tutorials, usage examples, or narrative prose.
+
+---
+
+## Testing Rules
+
+- Must not access private members (`_name`) in tests — test only the public API.
+- Shared fixtures Must live in the nearest `conftest.py`.
+- Fixture factory return types Must be annotated as `Callable[..., T]`.
+- `MockerFixture` parameters Must be type-annotated.
+- Must not add free-standing comments between test methods; use `# --- section ---` separators only.
+
+---
+
+## Inputs and Validation
+
+- Action inputs Must be read exclusively from environment variables.
+- Parsing and validation Must be centralised in one layer (`ActionInputs`).
+- Must not duplicate validation logic across modules.
+
+---
+
+## Code Quality
+
+- Every `.py` file including `__init__.py` Must carry the project copyright header.
+- Must not introduce bare `# type: ignore` without an inline justification comment.
+- Must not add `# pylint: disable` inline — use `.pylintrc` entries instead.
+
+---
+
+## QA Gate Commands
+
+Run these before marking any task done:
+
+```shell
+pytest --cov=. tests/ --cov-fail-under=80
+pylint $(git ls-files '*.py')
+black --check $(git ls-files '*.py')
+mypy .
+```
+
+All four Must pass with no errors before a PR is opened.
+
+---
+
+## Common Pitfalls
+
+- Avoid commenting out code and leaving it — delete or implement.
+- Avoid `continue-on-error: true` in CI steps that gate correctness.
+- Avoid storing inter-step values in `$GITHUB_ENV` — use `$GITHUB_OUTPUT`.
+- Avoid tag-pinned GitHub Actions (`@v3`) — prefer SHA digest pins.

--- a/.github/copilot-review-rules.md
+++ b/.github/copilot-review-rules.md
@@ -1,0 +1,56 @@
+# Copilot Review Rules — jacoco-report
+
+## Default Review
+
+Review every PR in this priority order:
+
+1. **Correctness** — logic errors, wrong conditions, off-by-one, silent failures
+2. **Security** — token/secret exposure in logs, injection risks, unvalidated external input
+3. **Tests** — missing cases, disabled scenarios left commented out, wrong assertions
+4. **Maintainability** — duplication, unclear naming, missing type hints
+5. **Style** — formatting, docstring gaps, import order
+
+Group all comments by severity before posting:
+
+- **Blocker** — Must be fixed before merge (correctness or security issue)
+- **Important** — Should be fixed; explain the risk if deferred
+- **Nit** — Optional improvement; prefix with `Nit:`
+
+Each comment Must state: _what the issue is_ + _why it matters_ + _the minimal fix_.
+
+---
+
+## Double-Check Mode
+
+Apply to PRs that touch: authentication, secrets handling, external API calls,
+data persistence, or any backward-incompatible change.
+
+Re-check explicitly:
+
+- Are secrets or tokens logged at any level?
+- Are all external calls guarded against pagination / rate limits?
+- Is the change idempotent under retries?
+- Does the change break any existing callers or action input contracts?
+- Are exit codes correct for all failure paths?
+
+---
+
+## Domain-Specific High-Risk Areas
+
+| Area | What to check |
+|------|--------------|
+| GitHub API calls | Pagination handled for >100 items; rate-limit errors surfaced, not swallowed |
+| Token handling | `GITHUB_TOKEN` / PAT never written to logs, comments, or output files |
+| PR comment format | Comment header string unchanged — consumers may parse it for deduplication |
+| Exit codes | Non-zero exit on threshold failure; zero exit when `fail-on-threshold` list is empty |
+| `skip-unchanged` filter | Applied at scan stage, not at display stage — filtering order must not change evaluation totals |
+
+---
+
+## Non-Goals
+
+Do not comment on:
+
+- Formatting already enforced by Black
+- Import order already enforced by linters
+- Naming that follows the existing project convention consistently


### PR DESCRIPTION
## Overview
Adds the AI coding contract for Copilot / Claude Code sessions on this project.
Without these files every AI session starts with no shared understanding of the
project's TDD workflow, quality gates, or review standards — leading to
inconsistent output and repeated correction.

## Changes
- `.github/copilot-instructions.md` — coding contract covering: TDD workflow
  (SPEC → test-case table → red-green cycle), output discipline, language rules
  (type hints, lazy-% logging, no print()), test rules, QA gate commands, and
  common pitfalls
- `.github/copilot-review-rules.md` — review framework covering: severity
  grouping (Blocker / Important / Nit), default review priority order,
  double-check mode for high-risk PRs, and domain-specific risk areas
  (GitHub API pagination, token leakage, comment-format contract, exit codes)

## How to verify
Open a new Copilot or Claude Code session in this repo — both files are
automatically picked up as context.

## Related
Closes #136 

## Release Notes
- Introduced Copilot instrument files.