### PR TITLE
Chore/add pylintrc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,14 +86,7 @@
       "Read(//opt/**)",
       "Read(//opt/homebrew/**)",
       "Bash(/usr/local/Cellar/python@3.14/3.14.4_1/bin/python3.14 -m venv venv --clear)",
-      "Bash(venv/bin/pip install *)",
-      "Bash(sed -n '195,215p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(sed -n '283,295p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(sed -n '220,245p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(sed -n '260,285p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(sed -n '348,365p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(sed -n '406,425p' jacoco_report/generator/pr_comment_generator.py)",
-      "Bash(echo \"exit $?\")"
+      "Bash(venv/bin/pip install *)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,7 +86,14 @@
       "Read(//opt/**)",
       "Read(//opt/homebrew/**)",
       "Bash(/usr/local/Cellar/python@3.14/3.14.4_1/bin/python3.14 -m venv venv --clear)",
-      "Bash(venv/bin/pip install *)"
+      "Bash(venv/bin/pip install *)",
+      "Bash(sed -n '195,215p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(sed -n '283,295p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(sed -n '220,245p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(sed -n '260,285p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(sed -n '348,365p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(sed -n '406,425p' jacoco_report/generator/pr_comment_generator.py)",
+      "Bash(echo \"exit $?\")"
     ]
   }
 }

--- a/.pylintrc
+++ b/.pylintrc
@@ -104,10 +104,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/.pylintrc
+++ b/.pylintrc
@@ -293,10 +293,10 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=15
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
@@ -305,7 +305,7 @@ max-bool-expr=5
 max-branches=12
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=20
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -317,7 +317,7 @@ max-positional-arguments=12
 max-public-methods=20
 
 # Maximum number of return / yield for function / method body.
-max-returns=6
+max-returns=7
 
 # Maximum number of statements in function / method body.
 max-statements=50
@@ -432,6 +432,24 @@ confidence=HIGH,
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
+#
+# --- Suppressed by design (no fix needed) ---
+# too-few-public-methods: data-container and model classes intentionally have few public methods
+# unsubscriptable-object (E1136): false positive on ET.ElementTree[ET.Element] generic annotation
+# duplicate-code: table-rendering patterns across comment generators are intentionally similar
+#
+# --- Tech-debt suppressions: keep until the underlying code is refactored ---
+#
+# too-many-arguments: raised max-args to 8 but 3 constructors still exceed it
+#   FileCoverage.__init__       9 args  → TODO: convert to @dataclass
+#   PRCommentGenerator._generate_reports_table_without_baseline  10 args  → TODO: introduce a TableConfig dataclass
+#   PRCommentGenerator._generate_reports_table_with_baseline     12 args  → TODO: same TableConfig refactor
+#
+# too-many-branches / too-many-statements: ActionInputs.validate_inputs() has 29 branches / 77 statements
+#   TODO: decompose validate_inputs() into focused per-input validator methods, one per logical input group
+#
+# too-many-public-methods: ActionInputs has 26 public methods (1 getter+validator per input field)
+#   TODO: consider splitting ActionInputs into focused groups (PathInputs, ThresholdInputs, DisplayInputs, etc.)
 disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
@@ -441,7 +459,14 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
-        use-implicit-booleaness-not-comparison-to-zero
+        use-implicit-booleaness-not-comparison-to-zero,
+        too-few-public-methods,
+        unsubscriptable-object,
+        duplicate-code,
+        too-many-arguments,
+        too-many-branches,
+        too-many-statements,
+        too-many-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -34,7 +34,6 @@ from jacoco_report.utils.github import GitHub
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-branches, too-many-statements, too-many-locals, too-many-public-methods
 class ActionInputs:
     """
     A class representing the inputs provided to the GH action.
@@ -375,7 +374,6 @@ class ActionInputs:
 
         return []
 
-    # pylint: disable=too-many-return-statements
     @staticmethod
     def validate_module_threshold(input_module_threshold: str) -> list[str]:
         """
@@ -596,31 +594,44 @@ class ActionInputs:
         if not isinstance(debug, bool):
             errors.append("'debug' must be a boolean.")
 
-        # pylint: disable=W1203
         logger.info(
             "[CONFIGURATION] Received input values:\n"
-            f"Paths: {ActionInputs.get_paths()}\n"
-            f"Exclude paths: {ActionInputs.get_exclude_paths()}\n"
-            f"Baseline paths: {ActionInputs.get_baseline_paths()}\n"
+            "Paths: %s\n"
+            "Exclude paths: %s\n"
+            "Baseline paths: %s\n"
             "\n"
-            f"Global thresholds: overall={ActionInputs.get_global_overall_threshold()}, "
-            f"avg_changed_files={ActionInputs.get_global_changed_files_average_threshold()}, "
-            f"changed_file={ActionInputs.get_global_changed_file_threshold()}\n"
+            "Global thresholds: overall=%s, avg_changed_files=%s, changed_file=%s\n"
             "\n"
-            f"Modules: {ActionInputs.get_modules()}\n"
-            f"Modules thresholds: {ActionInputs.get_modules_thresholds()}\n"
+            "Modules: %s\n"
+            "Modules thresholds: %s\n"
             "\n"
-            f"Metric: {ActionInputs.get_metric()}\n"
-            f"Title: {ActionInputs.get_title()}\n"
-            f"Comment level: {ActionInputs.get_comment_level()}\n"
+            "Metric: %s\n"
+            "Title: %s\n"
+            "Comment level: %s\n"
             "\n"
-            f"Skip unchanged: {ActionInputs.get_skip_unchanged()}\n"
-            f"Update comment: {ActionInputs.get_update_comment()}\n"
-            f"Fail on threshold: {fail_on_threshold if fail_on_threshold else []}\n"
-            f"Debug logging enabled: {ActionInputs.get_debug()}"
-            "\n"
-            f"Pass symbol: {ActionInputs.get_pass_symbol()}\n"
-            f"Fail symbol: {ActionInputs.get_fail_symbol()}\n"
+            "Skip unchanged: %s\n"
+            "Update comment: %s\n"
+            "Fail on threshold: %s\n"
+            "Debug logging enabled: %s\n"
+            "Pass symbol: %s\n"
+            "Fail symbol: %s",
+            ActionInputs.get_paths(),
+            ActionInputs.get_exclude_paths(),
+            ActionInputs.get_baseline_paths(),
+            ActionInputs.get_global_overall_threshold(),
+            ActionInputs.get_global_changed_files_average_threshold(),
+            ActionInputs.get_global_changed_file_threshold(),
+            ActionInputs.get_modules(),
+            ActionInputs.get_modules_thresholds(),
+            ActionInputs.get_metric(),
+            ActionInputs.get_title(),
+            ActionInputs.get_comment_level(),
+            ActionInputs.get_skip_unchanged(),
+            ActionInputs.get_update_comment(),
+            fail_on_threshold if fail_on_threshold else [],
+            ActionInputs.get_debug(),
+            ActionInputs.get_pass_symbol(),
+            ActionInputs.get_fail_symbol(),
         )
 
         # Log errors if any

--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -15,7 +15,6 @@ from jacoco_report.model.module import Module
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class CoverageEvaluator:
     """
     A class evaluating the coverage of the reports.
@@ -23,7 +22,6 @@ class CoverageEvaluator:
     to check if they pass the thresholds.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         report_files_coverage: list[ReportFileCoverage],
@@ -60,7 +58,6 @@ class CoverageEvaluator:
         self.reached_threshold_changed_files_average: bool = True
         self.reached_threshold_per_change_file: bool = True
 
-    # pylint: disable=too-many-locals
     def evaluate(self) -> None:
         """
         Evaluates the coverage of the all reports.
@@ -160,7 +157,6 @@ class CoverageEvaluator:
         # review for violations
         self._review_violations()
 
-    # pylint: disable=too-many-branches, too-many-statements
     def _review_violations(self) -> None:
         """
         Reviews the coverage evaluation results and appends violations to the violations list.

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -227,8 +227,7 @@ class PRCommentGenerator:
 
             name = evaluated_report.name
             overall_cov = evaluated_report.overall_coverage_reached
-            avg_cov = evaluated_report.avg_changed_files_coverage_reached
-            cov = f"{overall_cov}% / {avg_cov}%"
+            cov = f"{overall_cov}% / {evaluated_report.avg_changed_files_coverage_reached}%"
             thres = f"{o_thres}% / {ch_thres}%"
             status_o = p if evaluated_report.overall_passed else f
             status_ch = p if evaluated_report.avg_changed_files_passed else f
@@ -263,19 +262,17 @@ class PRCommentGenerator:
                 o_thres = evaluated_report.overall_coverage_threshold
                 ch_thres = evaluated_report.changed_files_threshold
 
+            name = evaluated_report.name
             overall_cov = evaluated_report.overall_coverage_reached
-            avg_cov = evaluated_report.avg_changed_files_coverage_reached
-            cov = f"{overall_cov}% / {avg_cov}%"
+            cov = f"{overall_cov}% / {evaluated_report.avg_changed_files_coverage_reached}%"
+            thres = f"{o_thres}% / {ch_thres}%"
             delta = (
-                f"{'+'if diff_o > 0.001 else ''}{round(diff_o, 2)}%"
-                f" / {'+'if diff_ch > 0.001 else ''}{round(diff_ch, 2)}%"
+                f"{'+' if diff_o > 0.001 else ''}{round(diff_o, 2)}%"
+                f" / {'+' if diff_ch > 0.001 else ''}{round(diff_ch, 2)}%"
             )
             status_o = p if evaluated_report.overall_passed else f
             status_ch = p if evaluated_report.avg_changed_files_passed else f
-            s += (
-                f"\n| `{evaluated_report.name}` | {cov}"
-                f" | {o_thres}% / {ch_thres}% | {delta} | {status_o}/{status_ch} |"
-            )
+            s += f"\n| `{name}` | {cov} | {thres} | {delta} | {status_o}/{status_ch} |"
 
         if provided_reports == 0:
             s += "\n\nNo changed file in reports."

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -17,13 +17,11 @@ from jacoco_report.utils.github import GitHub
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class PRCommentGenerator:
     """
     A class that represents the PR Comment Generator.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         gh: GitHub,
@@ -87,7 +85,6 @@ class PRCommentGenerator:
         return title, body
 
     def _get_basic_table_for_all(self, p: str, f: str) -> str:
-        # pylint: disable=duplicate-code
         if not ActionInputs.get_baseline_paths():
             return self._get_basic_table(
                 p,
@@ -198,8 +195,7 @@ class PRCommentGenerator:
 
         return self._generate_reports_table_with_baseline(p, f)
 
-    # pylint: disable=unused-argument
-    def _generate_reports_table__skip(self, evaluated_report: EvaluatedReportCoverage, **kwargs) -> bool:
+    def _generate_reports_table__skip(self, evaluated_report: EvaluatedReportCoverage, **_kwargs) -> bool:
         if (
             ActionInputs.get_skip_unchanged()
             and evaluated_report.name not in self.changed_modules
@@ -229,16 +225,14 @@ class PRCommentGenerator:
                 o_thres = evaluated_report.overall_coverage_threshold
                 ch_thres = evaluated_report.changed_files_threshold
 
-            # pylint: disable=C0209
-            s += "\n| `{}` | {}% / {}% | {}% / {}% | {}/{} |".format(
-                evaluated_report.name,
-                evaluated_report.overall_coverage_reached,
-                evaluated_report.avg_changed_files_coverage_reached,
-                o_thres,
-                ch_thres,
-                p if evaluated_report.overall_passed else f,
-                p if evaluated_report.avg_changed_files_passed else f,
-            )
+            name = evaluated_report.name
+            overall_cov = evaluated_report.overall_coverage_reached
+            avg_cov = evaluated_report.avg_changed_files_coverage_reached
+            cov = f"{overall_cov}% / {avg_cov}%"
+            thres = f"{o_thres}% / {ch_thres}%"
+            status_o = p if evaluated_report.overall_passed else f
+            status_ch = p if evaluated_report.avg_changed_files_passed else f
+            s += f"\n| `{name}` | {cov} | {thres} | {status_o}/{status_ch} |"
 
         if provided_reports == 0:
             s += "\n\nNo changed file in reports."
@@ -269,19 +263,18 @@ class PRCommentGenerator:
                 o_thres = evaluated_report.overall_coverage_threshold
                 ch_thres = evaluated_report.changed_files_threshold
 
-            # pylint: disable=C0209
-            s += "\n| `{}` | {}% / {}% | {}% / {}% | {}{}% / {}{}% | {}/{} |".format(
-                evaluated_report.name,
-                evaluated_report.overall_coverage_reached,
-                evaluated_report.avg_changed_files_coverage_reached,
-                o_thres,
-                ch_thres,
-                "+" if diff_o > 0.001 else "",
-                round(diff_o, 2),
-                "+" if diff_ch > 0.001 else "",
-                round(diff_ch, 2),
-                p if evaluated_report.overall_passed else f,
-                p if evaluated_report.avg_changed_files_passed else f,
+            overall_cov = evaluated_report.overall_coverage_reached
+            avg_cov = evaluated_report.avg_changed_files_coverage_reached
+            cov = f"{overall_cov}% / {avg_cov}%"
+            delta = (
+                f"{'+'if diff_o > 0.001 else ''}{round(diff_o, 2)}%"
+                f" / {'+'if diff_ch > 0.001 else ''}{round(diff_ch, 2)}%"
+            )
+            status_o = p if evaluated_report.overall_passed else f
+            status_ch = p if evaluated_report.avg_changed_files_passed else f
+            s += (
+                f"\n| `{evaluated_report.name}` | {cov}"
+                f" | {o_thres}% / {ch_thres}% | {delta} | {status_o}/{status_ch} |"
             )
 
         if provided_reports == 0:
@@ -289,8 +282,7 @@ class PRCommentGenerator:
 
         return s
 
-    # pylint: disable=unused-argument
-    def _generate_modules_table__skip(self, evaluated_report: EvaluatedReportCoverage, **kwargs) -> bool:
+    def _generate_modules_table__skip(self, evaluated_report: EvaluatedReportCoverage, **_kwargs) -> bool:
         if (
             ActionInputs.get_skip_unchanged()
             and evaluated_report.name not in self.changed_modules
@@ -359,12 +351,11 @@ class PRCommentGenerator:
                     f"https://github.com/{self.github_repository}/pull/{self.pr_number}/files#diff-{file_hash}"
                 )
 
-                # pylint: disable=C0209
-                line = "\n| {} | {}% | {}% | {} |".format(
-                    f"[{filename}]({file_as_link_to_diff})",
-                    evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key],
-                    evaluated_reports_coverage[ecr_key].per_changed_file_threshold,
-                    (p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f),
+                line = (
+                    f"\n| [{filename}]({file_as_link_to_diff})"
+                    f" | {evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]}%"
+                    f" | {evaluated_reports_coverage[ecr_key].per_changed_file_threshold}%"
+                    f" | {p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f} |"
                 )
                 lines.append(line)
 
@@ -418,14 +409,12 @@ class PRCommentGenerator:
                         - self.bs_evaluator.evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]
                     )
 
-                # pylint: disable=C0209
-                line = "\n| {} | {}% | {}% | {}{}% | {} |".format(
-                    f"[{filename}]({file_as_link_to_diff})",
-                    evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key],
-                    evaluated_reports_coverage[ecr_key].per_changed_file_threshold,
-                    "+" if diff > 0.001 else "",
-                    round(diff, 2),
-                    (p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f),
+                line = (
+                    f"\n| [{filename}]({file_as_link_to_diff})"
+                    f" | {evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]}%"
+                    f" | {evaluated_reports_coverage[ecr_key].per_changed_file_threshold}%"
+                    f" | {'+' if diff > 0.001 else ''}{round(diff, 2)}%"
+                    f" | {p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f} |"
                 )
                 lines.append(line)
 

--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -18,7 +18,6 @@ from jacoco_report.utils.github import GitHub
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods,too-many-instance-attributes
 class JaCoCoReport:
     """
     A class representing the JaCoCo Report.
@@ -39,7 +38,6 @@ class JaCoCoReport:
         self.reached_threshold_changed_files_average = True
         self.reached_threshold_per_change_file = True
 
-    # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     def run(self) -> None:
         """
         The main function to run the JaCoCo GitHub Action adding the JaCoCo coverage report to the pull request.

--- a/jacoco_report/model/counter.py
+++ b/jacoco_report/model/counter.py
@@ -5,7 +5,6 @@ A module that contains the Counter class.
 from typing import Union, Optional
 
 
-# pylint: disable=too-few-public-methods
 class Counter:
     """
     A class that represents a counter

--- a/jacoco_report/model/coverage.py
+++ b/jacoco_report/model/coverage.py
@@ -10,13 +10,11 @@ from jacoco_report.utils.enums import MetricTypeEnum
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class Coverage:
     """
     A class that represents the coverage of a file
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self, instruction: Counter, branch: Counter, line: Counter, complexity: Counter, method: Counter, clazz: Counter
     ):
@@ -38,7 +36,6 @@ class Coverage:
         self.method: Counter = method
         self.clazz: Counter = clazz
 
-    # pylint: disable=too-many-return-statements
     def get_coverage_by_metric(self, metric_type: str) -> float:
         """
         Returns the coverage of the given counter

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -5,7 +5,6 @@ A module that contains the EvaluatedCoverage class.
 from jacoco_report.model.counter import Counter
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class EvaluatedReportCoverage:
     """
     A class that represents an evaluated coverage of one report file or module.

--- a/jacoco_report/model/file_coverage.py
+++ b/jacoco_report/model/file_coverage.py
@@ -6,13 +6,11 @@ from jacoco_report.model.counter import Counter
 from jacoco_report.model.coverage import Coverage
 
 
-# pylint: disable=too-few-public-methods
 class FileCoverage(Coverage):
     """
     A class that represents the coverage of a file
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         file_name: str,

--- a/jacoco_report/model/module.py
+++ b/jacoco_report/model/module.py
@@ -3,13 +3,11 @@ A module that contains the class that represents a module in a project.
 """
 
 
-# pylint: disable=too-few-public-methods
 class Module:
     """
     A class that represents a module in a project.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         name: str,

--- a/jacoco_report/model/report_file_coverage.py
+++ b/jacoco_report/model/report_file_coverage.py
@@ -8,14 +8,12 @@ from jacoco_report.model.coverage import Coverage
 from jacoco_report.model.file_coverage import FileCoverage
 
 
-# pylint: disable=too-few-public-methods
 class ReportFileCoverage:
     """
     A class that represents the coverage of a report file.
     Class variables are filled with data from the XML report file.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         path: str,

--- a/jacoco_report/parser/jacoco_report_parser.py
+++ b/jacoco_report/parser/jacoco_report_parser.py
@@ -16,7 +16,6 @@ from jacoco_report.model.file_coverage import FileCoverage
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class JaCoCoReportParser:
     """
     A class for parsing JaCoCo XML reports and creating CoverageReport instances.
@@ -37,7 +36,6 @@ class JaCoCoReportParser:
             A CoverageReport instance.
         """
         logger.debug("Parsing JaCoCo XML report: %s", report_path)
-        # pylint: disable=unsubscriptable-object
         tree: ET.ElementTree[ET.Element] = ET.parse(report_path)
         root: Optional[ET.Element] = tree.getroot()
 
@@ -139,8 +137,7 @@ class JaCoCoReportParser:
 
         def find_file(root_dir: str, relative_path: str) -> list[str]:
             paths: list[str] = []
-            # pylint: disable=unused-variable
-            for dirpath, _, filenames in os.walk(root_dir):
+            for dirpath, *_ in os.walk(root_dir):
                 full_path = os.path.join(dirpath, relative_path)
                 if os.path.isfile(full_path):
                     paths.append(os.path.relpath(full_path, root_dir))

--- a/jacoco_report/parser/module_parser.py
+++ b/jacoco_report/parser/module_parser.py
@@ -6,7 +6,6 @@ from jacoco_report.action_inputs import ActionInputs
 from jacoco_report.model.module import Module
 
 
-# pylint: disable=too-few-public-methods
 class ModuleParser:
     """
     A class that parses the module information from the action inputs.

--- a/jacoco_report/scanner/jacoco_report_input_scanner.py
+++ b/jacoco_report/scanner/jacoco_report_input_scanner.py
@@ -9,7 +9,6 @@ import os
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class JaCoCoReportInputScanner:
     """
     A class for scanning input paths for JaCoCo XML files and excluding specified paths.


### PR DESCRIPTION
## Overview

Centralise Pylint configuration: move all per-file `# pylint: disable` inline comments into `.pylintrc`,
fix the underlying issues where possible, and document remaining tech-debt suppressions with actionable TODOs.

**What changed:**
- Removed 14 inline `# pylint: disable` directives across 13 source files
- Fixed 4 genuine code issues (unused loop var, f-string logging, `.format()` → f-strings, unused `**kwargs`)
- Raised 4 thresholds (`max-args`, `max-attributes`, `max-locals`, `max-returns`) to reflect actual class/function sizes
- Kept 4 global suppressions for real tech-debt (`too-many-arguments`, `too-many-branches`, `too-many-statements`,
  `too-many-public-methods`) — each annotated with a TODO and the specific refactor needed
- Removed `suggestion-mode` (unrecognised option causing `E0015` on every pylint run)

Release Notes:

- No functional changes — internal tooling / code quality only.
