### PR TITLE
chore: eliminate private member access in tests by promoting methods to public

### DIFF
--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -140,7 +140,7 @@ class CoverageEvaluator:
                 )
 
                 # save the evaluated module
-                self.evaluated_modules_coverage[module_name] = self._evaluate_module(evaluated_coverage_module)
+                self.evaluated_modules_coverage[module_name] = self.evaluate_module(evaluated_coverage_module)
 
         # evaluate the global coverage values
         self.total_coverage_overall = global_overall.coverage()
@@ -155,9 +155,9 @@ class CoverageEvaluator:
             )
 
         # review for violations
-        self._review_violations()
+        self.review_violations()
 
-    def _review_violations(self) -> None:
+    def review_violations(self) -> None:
         """
         Reviews the coverage evaluation results and appends violations to the violations list.
         Global violations are only reported when comment mode is set to SINGLE.
@@ -233,7 +233,7 @@ class CoverageEvaluator:
         self.violations.extend(report_violations)
         self.violations.extend(changed_files_violations)
 
-    def _evaluate_module(self, evaluated_coverage: EvaluatedReportCoverage) -> EvaluatedReportCoverage:
+    def evaluate_module(self, evaluated_coverage: EvaluatedReportCoverage) -> EvaluatedReportCoverage:
         """
         Evaluates the coverage of the one module.
         Evaluation uses modules thresholds if defined, otherwise global thresholds.

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -73,7 +73,7 @@ class PRCommentGenerator:
         p = ActionInputs.get_pass_symbol()
         f = ActionInputs.get_fail_symbol()
 
-        body += f"\n\n{self._get_basic_table_for_all(p, f)}"
+        body += f"\n\n{self.get_basic_table_for_all(p, f)}"
 
         if ActionInputs.get_comment_level() == CommentLevelEnum.FULL:
             reports_table = self._get_reports_table(p, f)
@@ -84,9 +84,9 @@ class PRCommentGenerator:
 
         return title, body
 
-    def _get_basic_table_for_all(self, p: str, f: str) -> str:
+    def get_basic_table_for_all(self, p: str, f: str) -> str:
         if not ActionInputs.get_baseline_paths():
-            return self._get_basic_table(
+            return self.get_basic_table(
                 p,
                 f,
                 ActionInputs.get_metric(),
@@ -98,7 +98,7 @@ class PRCommentGenerator:
                 ActionInputs.get_global_changed_files_average_threshold(),
             )
 
-        return self._get_basic_table_with_baseline(
+        return self.get_basic_table_with_baseline(
             p,
             f,
             ActionInputs.get_metric(),
@@ -118,7 +118,7 @@ class PRCommentGenerator:
     # | **Overall**          | 85.2%    | 80%       | +1,3%      | ✅      |
     # | **Changed Files**    | 78.4%    | 80%       | 0.3%       | ❌      |
 
-    def _get_basic_table(
+    def get_basic_table(
         self,
         p: str,
         f: str,
@@ -149,7 +149,7 @@ class PRCommentGenerator:
             )
         )
 
-    def _get_basic_table_with_baseline(
+    def get_basic_table_with_baseline(
         self,
         p: str,
         f: str,
@@ -288,7 +288,7 @@ class PRCommentGenerator:
             return True
         return False
 
-    def _calculate_baseline_module_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
+    def calculate_baseline_module_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
         if evaluated_coverage.name not in self.bs_evaluator.evaluated_modules_coverage.keys():
             return 0.0, 0.0
 
@@ -325,7 +325,7 @@ class PRCommentGenerator:
     # | `src/main/java/com/example/File2.java`         | 70.5%    | 80%       | -1.0%      | ❌      |
     # | `src/main/java/com/example/File3.java`         | 82.1%    | 80%       | +2.7%      | ✅      |
 
-    def _generate_changed_files_table_without_baseline(
+    def generate_changed_files_table_without_baseline(
         self, p: str, f: str, evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None
     ) -> str:
         """
@@ -369,11 +369,11 @@ class PRCommentGenerator:
             return "\nNo changed file in reports."
 
         if not ActionInputs.get_baseline_paths():
-            return self._generate_changed_files_table_without_baseline(p, f)
+            return self.generate_changed_files_table_without_baseline(p, f)
 
-        return self._generate_changed_files_table_with_baseline(p, f)
+        return self.generate_changed_files_table_with_baseline(p, f)
 
-    def _generate_changed_files_table_with_baseline(
+    def generate_changed_files_table_with_baseline(
         self, p: str, f: str, evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None
     ) -> str:
         s = dedent("""

--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -57,7 +57,7 @@ class JaCoCoReport:
         logger.info("Pull request number: %s", pr_number)
 
         logger.info("Scanning for JaCoCo (xml) reports.")
-        input_report_paths_to_analyse = self._scan_jacoco_xml_files(
+        input_report_paths_to_analyse = self.scan_jacoco_xml_files(
             paths=ActionInputs.get_paths(), exclude_paths=ActionInputs.get_exclude_paths()
         )
 
@@ -88,7 +88,7 @@ class JaCoCoReport:
 
         # get baseline files for comparison
         logger.info("Scanning for JaCoCo (xml) baseline reports.")
-        baseline_report_paths_to_analyse = self._scan_jacoco_xml_files(
+        baseline_report_paths_to_analyse = self.scan_jacoco_xml_files(
             paths=ActionInputs.get_baseline_paths(), exclude_paths=[]
         )
         bs_report_files_coverage: list[ReportFileCoverage] = []
@@ -144,7 +144,7 @@ class JaCoCoReport:
         generator.generate()
         logger.info("PR comment(s) generated successfully.")
 
-    def _scan_jacoco_xml_files(self, paths: list[str], exclude_paths: list[str]) -> list[str]:
+    def scan_jacoco_xml_files(self, paths: list[str], exclude_paths: list[str]) -> list[str]:
         # get files jacoco xml files for analysis
         paths_to_analyse: list[str] = JaCoCoReportInputScanner(paths=paths, exclude_paths=exclude_paths).scan()
         logger.info("Found %s JaCoCo reports.", len(paths_to_analyse))

--- a/jacoco_report/utils/github.py
+++ b/jacoco_report/utils/github.py
@@ -83,7 +83,7 @@ class GitHub:
             params = {"per_page": per_page, "page": page}
             logger.debug("GitHub - URL: %s, Page: %d", api_url, page)
 
-            response = self._send_request("GET", api_url, params=params)
+            response = self.send_request("GET", api_url, params=params)
             if response is None:
                 logger.error("Failed to get the list of changed files.")
                 return None
@@ -104,7 +104,7 @@ class GitHub:
         logger.info("List of changed files in PR: %s", file_list)
         return file_list
 
-    def _send_request(
+    def send_request(
         self, method: str, url: str, data: Optional[dict] = None, params: Optional[dict] = None
     ) -> Optional[requests.Response]:
         """
@@ -212,7 +212,7 @@ class GitHub:
         # Prepare the comment data
         comment_data = {"body": body}
 
-        response = self._send_request("POST", api_url, data=comment_data)
+        response = self.send_request("POST", api_url, data=comment_data)
         if response is None:
             logger.error("Failed to add a comment to the PR.")
             return False
@@ -241,7 +241,7 @@ class GitHub:
             api_url = f"{self.__gh_url}/repos/{repo}/issues/{pr_number}/comments" f"?per_page={per_page}&page={page}"
             logger.debug("GitHub - URL (page %d): %s", page, api_url)
 
-            response = self._send_request("GET", api_url)
+            response = self.send_request("GET", api_url)
             if response is None:
                 logger.error("Failed to get PR comments.")
                 break
@@ -281,7 +281,7 @@ class GitHub:
 
         payload = {"body": pr_body}
 
-        response = self._send_request("PATCH", api_url, data=payload)
+        response = self.send_request("PATCH", api_url, data=payload)
 
         if response is None:
             logger.error("Failed to update the comment with ID %d.", comment_id)
@@ -310,7 +310,7 @@ class GitHub:
         api_url = f"{self.__gh_url}/repos/{repo}/issues/comments/{comment_id}"
         logger.debug("GitHub - Delete Comment URL: %s", api_url)
 
-        response = self._send_request("DELETE", api_url)
+        response = self.send_request("DELETE", api_url)
 
         if response is None or response.status_code != 204:
             logger.error("Failed to delete the comment with ID %d.", comment_id)

--- a/tests/evaluator/test_coverage_evaluator.py
+++ b/tests/evaluator/test_coverage_evaluator.py
@@ -61,9 +61,13 @@ def test_evaluate_changed_files_coverage(evaluator):
     assert evaluator.total_coverage_changed_files == pytest.approx(90.0, 0.01)
     assert evaluator.total_coverage_changed_files_passed is True
 
-def test_evaluate_with_low_thresholds(evaluator):
-    evaluator._global_min_coverage_overall = 70.0
-    evaluator._global_min_coverage_changed_files = 95.0
+def test_evaluate_with_low_thresholds(sample_report_file_coverage):
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[sample_report_file_coverage],
+        global_min_coverage_overall=70.0,
+        global_min_coverage_changed_files=95.0,
+        global_min_coverage_changed_per_file=50.0
+    )
     evaluator.evaluate()
     assert evaluator.total_coverage_overall_passed is False
     assert evaluator.total_coverage_changed_files_passed is False
@@ -77,7 +81,7 @@ def test_review_violations_global_overall_coverage_below_threshold(evaluator,):
     evaluator.total_coverage_overall_passed = False
     evaluator.total_coverage_changed_files_passed = True
 
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert "Global overall coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -88,7 +92,7 @@ def test_review_violations_global_overall_coverage_below_threshold_minimal(evalu
     evaluator.total_coverage_overall_passed = True
     evaluator.total_coverage_changed_files_passed = True
 
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert evaluator.violations == []
 
@@ -99,7 +103,7 @@ def test_review_violations_global_changed_files_coverage_below_threshold(evaluat
     evaluator.total_coverage_overall_passed = True
     evaluator.total_coverage_changed_files_passed = False
 
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert "Global changed files coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -110,7 +114,7 @@ def test_review_violations_global_changed_files_coverage_zero_no_changed_file(ev
     evaluator.total_coverage_overall_passed = True
     evaluator.total_coverage_changed_files_passed = True
 
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert len(evaluator.violations) == 0
 
@@ -121,7 +125,7 @@ def test_review_violations_global_changed_files_coverage_zero_w_changed_file(eva
     evaluator.total_coverage_overall_passed = True
     evaluator.total_coverage_changed_files_passed = False
 
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert "Global changed files coverage 0.0 is below the threshold 50.0." in evaluator.violations
 
@@ -144,7 +148,7 @@ def test_review_violations_global_changed_files_coverage_zero_w_changed_file(eva
 #     evaluator.evaluated_modules_coverage = {
 #         "module-a": module_evaluated_coverage
 #     }
-#     evaluator._review_violations()
+#     evaluator.review_violations()
 #
 #     assert "Module 'module-a' overall coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -170,7 +174,7 @@ def test_review_violations_global_changed_files_coverage_zero_w_changed_file(eva
 #     evaluator.evaluated_modules_coverage = {
 #         "module-a": module_evaluated_coverage
 #     }
-#     evaluator._review_violations()
+#     evaluator.review_violations()
 #
 #     assert "Module 'module-a' changed files coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -188,7 +192,7 @@ def test_review_violations_report_overall_coverage_below_threshold(evaluator, mo
     evaluator.evaluated_reports_coverage = {
         "filepath": report_evaluated_coverage
     }
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert "Report 'filepath' overall coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -217,7 +221,7 @@ def test_review_violations_report_changed_files_coverage_below_threshold(evaluat
     evaluator.evaluated_reports_coverage = {
         "filepath": report_evaluated_coverage
     }
-    evaluator._review_violations()
+    evaluator.review_violations()
 
     assert "Report 'filepath' changed files coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
@@ -268,7 +272,7 @@ def test_evaluate_module_with_patched_thresholds(mocker):
     evaluated_coverage_module.overall_coverage.missed = 0
 
     # Evaluate the module
-    evaluated_coverage_module = evaluator._evaluate_module(evaluated_coverage_module)
+    evaluated_coverage_module = evaluator.evaluate_module(evaluated_coverage_module)
 
     # Assert that the overall coverage reached is 0.0 and it passed
     assert evaluated_coverage_module.overall_coverage_reached == 0.0

--- a/tests/generator/test_pr_comment_generator.py
+++ b/tests/generator/test_pr_comment_generator.py
@@ -30,8 +30,8 @@ def test_evaluator(mocker):
 def pr_comment_generator(mock_github, test_evaluator):
     return PRCommentGenerator(mock_github, test_evaluator, None, 1)
 
-def test_get_basic_table(pr_comment_generator, mocker):
-    table = pr_comment_generator._get_basic_table(
+def testget_basic_table(pr_comment_generator, mocker):
+    table = pr_comment_generator.get_basic_table(
         "✅", "❌", MetricTypeEnum.INSTRUCTION,
         85.2, True, 80.0,
         78.4, False, 80.0
@@ -41,11 +41,11 @@ def test_get_basic_table(pr_comment_generator, mocker):
     assert "| **Changed Files** | 78.4% | 80.0% | ❌ |" in table
 
 def test_get_changed_files_table_without_baseline(pr_comment_generator):
-    table = pr_comment_generator._generate_changed_files_table_without_baseline("✅", "❌")
+    table = pr_comment_generator.generate_changed_files_table_without_baseline("✅", "❌")
     assert "| File Path | Coverage | Threshold | Status |\n|-----------|----------|-----------|--------|\n\nNo changed file in reports." in table
 
 def test_get_changed_files_table_with_baseline(pr_comment_generator):
-    table = pr_comment_generator._generate_changed_files_table_with_baseline("✅", "❌")
+    table = pr_comment_generator.generate_changed_files_table_with_baseline("✅", "❌")
     assert "| File Path | Coverage | Threshold | Δ Coverage | Status |\n|-----------|----------|-----------|------------|--------|\n\nNo changed file in reports." in table
 
 def test_calculate_module_diff(pr_comment_generator, mocker):
@@ -64,7 +64,7 @@ def test_calculate_module_diff(pr_comment_generator, mocker):
     evaluated_coverage_module.avg_changed_files_coverage_reached = 85.0
 
     # Calculate the differences
-    diff_o, diff_ch = pr_comment_generator._calculate_baseline_module_diffs(evaluated_coverage_module)
+    diff_o, diff_ch = pr_comment_generator.calculate_baseline_module_diffs(evaluated_coverage_module)
 
     # Assert the differences are calculated correctly
     assert diff_o == 10.0
@@ -82,13 +82,13 @@ def test_calculate_module_diff_no_module_in_baseline(pr_comment_generator, mocke
     evaluated_coverage_module.avg_changed_files_coverage_reached = 85.0
 
     # Calculate the differences
-    diff_o, diff_ch = pr_comment_generator._calculate_baseline_module_diffs(evaluated_coverage_module)
+    diff_o, diff_ch = pr_comment_generator.calculate_baseline_module_diffs(evaluated_coverage_module)
 
     # Assert the differences are zero since the module is not in the baseline
     assert diff_o == 0.0
     assert diff_ch == 0.0
 
-def test_generate_changed_files_table_with_baseline(pr_comment_generator, mocker):
+def testgenerate_changed_files_table_with_baseline(pr_comment_generator, mocker):
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
@@ -120,7 +120,7 @@ def test_generate_changed_files_table_with_baseline(pr_comment_generator, mocker
     }
 
     # Generate the table
-    table = pr_comment_generator._generate_changed_files_table_with_baseline("✅", "❌")
+    table = pr_comment_generator.generate_changed_files_table_with_baseline("✅", "❌")
 
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |
@@ -128,7 +128,7 @@ def test_generate_changed_files_table_with_baseline(pr_comment_generator, mocker
 | [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 0.0% | +10.0% | ✅ |"""
     assert table == expected_table
 
-def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage(pr_comment_generator, mocker):
+def testgenerate_changed_files_table_with_baseline_no_evaluated_report_coverage(pr_comment_generator, mocker):
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
@@ -160,7 +160,7 @@ def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage
     }
 
     # Generate the table
-    table = pr_comment_generator._generate_changed_files_table_with_baseline("✅", "❌")
+    table = pr_comment_generator.generate_changed_files_table_with_baseline("✅", "❌")
 
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |
@@ -168,7 +168,7 @@ def test_generate_changed_files_table_with_baseline_no_evaluated_report_coverage
 | [file1.java](https://github.com/fake_repo/pull/1/files#diff-fakehash) | 80.0% | 0.0% | 0.0% | ✅ |"""
     assert table == expected_table
 
-def test_generate_changed_files_table_with_baseline_no_changed_file(pr_comment_generator, mocker):
+def testgenerate_changed_files_table_with_baseline_no_changed_file(pr_comment_generator, mocker):
     # Mock the necessary methods and attributes
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=["baseline.xml"])
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_modules", return_value={"test", "test2"})
@@ -200,7 +200,7 @@ def test_generate_changed_files_table_with_baseline_no_changed_file(pr_comment_g
     }
 
     # Generate the table
-    table = pr_comment_generator._generate_changed_files_table_with_baseline("✅", "❌")
+    table = pr_comment_generator.generate_changed_files_table_with_baseline("✅", "❌")
 
     # Assert the table content
     expected_table = """| File Path | Coverage | Threshold | Δ Coverage | Status |

--- a/tests/parser/test_jacoco_report_parser.py
+++ b/tests/parser/test_jacoco_report_parser.py
@@ -85,12 +85,11 @@ def test_parse_changed_files_stats(parser, sample_jacoco_report):
     assert file_coverage.clazz == Counter(missed=0, covered=5)
 
 
-def test_file_not_in_changed_files(parser, sample_jacoco_report, caplog):
-    # Add a file that is not in the changed_files list
-    parser._changed_files = ["com/example/NonExistent.java"]
+def test_file_not_in_changed_files(sample_jacoco_report, caplog):
+    non_matching_parser = JaCoCoReportParser(changed_files=["com/example/NonExistent.java"], modules={})
 
     with caplog.at_level(logging.DEBUG):
-        parser.parse(sample_jacoco_report)
+        non_matching_parser.parse(sample_jacoco_report)
 
     assert "File 'com/example/Example.java' is not in the list of changed files." in caplog.text
 

--- a/tests/test_jacoco_report.py
+++ b/tests/test_jacoco_report.py
@@ -1907,7 +1907,7 @@ def test_run_no_jacoco_xml_files(jacoco_report, caplog, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=1)
-    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[])
+    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[])
     mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)
 
     with caplog.at_level(logging.ERROR):
@@ -1922,7 +1922,7 @@ def test_run_successful_empty_no_baseline(jacoco_report, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
-    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_b/target/jacoco_no_data.xml'])
+    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_b/target/jacoco_no_data.xml'])
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=[])
     mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)
 
@@ -1941,7 +1941,7 @@ def test_run_successful_empty_with_baseline(jacoco_report, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=['fake/path'])
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
-    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_b/target/jacoco_no_data.xml'])
+    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_b/target/jacoco_no_data.xml'])
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=[])
     mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)
 
@@ -1973,8 +1973,8 @@ def test_successful_one_source_file (jacoco_report, metric, comment, ov_cov, ch_
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value=metric)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value=CommentLevelEnum.MINIMAL)
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
-    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_c/target/jacoco_one_source_file.xml'])
-    # mocker.patch("jacoco_report.jacoco_report.JaCoCoReport._scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/data/module_c/target/jacoco_one_source_file.xml'])
+    mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_c/target/jacoco_one_source_file.xml'])
+    # mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/data/module_c/target/jacoco_one_source_file.xml'])
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_changed_files", return_value=['com/example/ExampleClass.java'])
 
     mock_add_comment = mocker.patch('jacoco_report.utils.github.GitHub.add_comment', return_value=None)

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -9,7 +9,7 @@ def test_get_pr_changed_files(mocker):
     mocker.patch("os.getenv", side_effect=lambda key: "fake_repo" if key == "GITHUB_REPOSITORY" else "refs/pull/1/merge")
     mock_response = mocker.Mock()
     mock_response.json.return_value = [{"filename": "file1.py"}, {"filename": "file2.py"}]
-    mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     files = github.get_pr_changed_files()
@@ -19,7 +19,7 @@ def test_get_pr_changed_files(mocker):
 
 def test_get_pr_changed_files_none_response(mocker):
     mocker.patch("os.getenv", side_effect=lambda key: "fake_repo" if key == "GITHUB_REPOSITORY" else "refs/pull/1/merge")
-    mocker.patch.object(GitHub, "_send_request", return_value=None)
+    mocker.patch.object(GitHub, "send_request", return_value=None)
     github = GitHub("fake_token")
 
     files = github.get_pr_changed_files()
@@ -27,9 +27,9 @@ def test_get_pr_changed_files_none_response(mocker):
     assert files is None
 
 
-# _send_request
+# send_request
 
-def test_send_request_get(mocker):
+def testsend_request_get(mocker):
     mock_session = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.raise_for_status = mocker.Mock()
@@ -37,14 +37,14 @@ def test_send_request_get(mocker):
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("GET", "https://api.github.com/test")
+    response = github.send_request("GET", "https://api.github.com/test")
 
     mock_session.get.assert_called_once_with("https://api.github.com/test", params=None)
     mock_response.raise_for_status.assert_called_once()
     assert response == mock_response
 
 
-def test_send_request_post(mocker):
+def testsend_request_post(mocker):
     mock_session = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.raise_for_status = mocker.Mock()
@@ -52,14 +52,14 @@ def test_send_request_post(mocker):
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("POST", "https://api.github.com/test", data={"key": "value"})
+    response = github.send_request("POST", "https://api.github.com/test", data={"key": "value"})
 
     mock_session.post.assert_called_once_with("https://api.github.com/test", json={"key": "value"}, params=None)
     mock_response.raise_for_status.assert_called_once()
     assert response == mock_response
 
 
-def test_send_request_patch(mocker):
+def testsend_request_patch(mocker):
     mock_session = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.raise_for_status = mocker.Mock()
@@ -67,14 +67,14 @@ def test_send_request_patch(mocker):
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("PATCH", "https://api.github.com/test", data={"key": "value"})
+    response = github.send_request("PATCH", "https://api.github.com/test", data={"key": "value"})
 
     mock_session.patch.assert_called_once_with("https://api.github.com/test", json={"key": "value"}, params=None)
     mock_response.raise_for_status.assert_called_once()
     assert response == mock_response
 
 
-def test_send_request_delete(mocker):
+def testsend_request_delete(mocker):
     mock_session = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.raise_for_status = mocker.Mock()
@@ -82,24 +82,24 @@ def test_send_request_delete(mocker):
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("DELETE", "https://api.github.com/test", data={"key": "value"})
+    response = github.send_request("DELETE", "https://api.github.com/test", data={"key": "value"})
 
     mock_session.delete.assert_called_once_with("https://api.github.com/test", json={"key": "value"}, params=None)
     mock_response.raise_for_status.assert_called_once()
     assert response == mock_response
 
 
-def test_send_request_unsupported_method(mocker):
+def testsend_request_unsupported_method(mocker):
     mock_logger = mocker.patch("jacoco_report.utils.github.logger")
     github = GitHub("fake_token")
 
-    response = github._send_request("PUT", "https://api.github.com/test")
+    response = github.send_request("PUT", "https://api.github.com/test")
 
     mock_logger.error.assert_called_once_with("Unsupported HTTP method: %s.", "PUT")
     assert response is None
 
 
-def test_send_request_get_http_error(mocker):
+def testsend_request_get_http_error(mocker):
     mock_session = mocker.Mock()
     mock_response = mocker.Mock()
     mock_response.raise_for_status.side_effect = requests.HTTPError("HTTP Error")
@@ -107,20 +107,20 @@ def test_send_request_get_http_error(mocker):
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("GET", "https://api.github.com/test")
+    response = github.send_request("GET", "https://api.github.com/test")
 
     mock_session.get.assert_called_once_with("https://api.github.com/test", params=None)
     mock_response.raise_for_status.assert_called_once()
     assert response is None
 
 
-def test_send_request_post_request_exception(mocker):
+def testsend_request_post_request_exception(mocker):
     mock_session = mocker.Mock()
     mock_session.post.side_effect = requests.RequestException("Request Exception")
     mocker.patch("requests.Session", return_value=mock_session)
     github = GitHub("fake_token")
 
-    response = github._send_request("POST", "https://api.github.com/test", data={"key": "value"})
+    response = github.send_request("POST", "https://api.github.com/test", data={"key": "value"})
 
     mock_session.post.assert_called_once_with("https://api.github.com/test", json={"key": "value"}, params=None)
     assert response is None
@@ -153,7 +153,7 @@ def test_get_pr_number_no_pr(mocker):
 def test_add_comment(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
     mock_response = mocker.Mock()
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     github.add_comment(1, "Test comment")
@@ -163,7 +163,7 @@ def test_add_comment(mocker):
 
 def test_add_comment_failed_request(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=None)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=None)
     github = GitHub("fake_token")
 
     github.add_comment(1, "Test comment")
@@ -177,7 +177,7 @@ def test_get_comments(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
     mock_response = mocker.Mock()
     mock_response.json.return_value = [{"body": "comment1"}, {"body": "comment2"}]
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     comments = github.get_comments(1)
@@ -197,7 +197,7 @@ def test_get_comments_pagination(mocker):
     mock_response_2.json.return_value = comments_page_2
 
     mocker.patch(
-        "jacoco_report.utils.github.GitHub._send_request",
+        "jacoco_report.utils.github.GitHub.send_request",
         side_effect=[mock_response_1, mock_response_2]
     )
 
@@ -220,7 +220,7 @@ def test_get_comments_unexpected_format(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
     mock_response = mocker.Mock()
     mock_response.json.return_value = {"body": "comment1"}
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     comments = github.get_comments(1)
@@ -239,7 +239,7 @@ def test_update_comment_success(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
     mock_response = mocker.Mock()
     mock_response.json.return_value = {"body": "Updated comment"}
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     result = github.update_comment(1, "Updated comment")
@@ -249,7 +249,7 @@ def test_update_comment_success(mocker):
 
 def test_update_comment_failed_request(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=None)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=None)
     github = GitHub("fake_token")
 
     result = github.update_comment(1, "Updated comment")
@@ -261,7 +261,7 @@ def test_update_comment_unexpected_response_format(mocker):
     mocker.patch("os.getenv", return_value="fake_repo")
     mock_response = mocker.Mock()
     mock_response.json.return_value = {"body": "unexpected_value"}
-    mock_send_req = mocker.patch.object(GitHub, "_send_request", return_value=mock_response)
+    mock_send_req = mocker.patch.object(GitHub, "send_request", return_value=mock_response)
     github = GitHub("fake_token")
 
     result = github.update_comment(1, "Updated comment")
@@ -275,27 +275,27 @@ def test_update_comment_unexpected_response_format(mocker):
 def test_delete_pr_comment_success(mocker, github):
     mock_response = mocker.Mock()
     mock_response.status_code = 204  # HTTP 204 No Content
-    mocker.patch.object(github, "_send_request", return_value=mock_response)
+    mocker.patch.object(github, "send_request", return_value=mock_response)
 
     result = github.delete_comment(123)
 
-    github._send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
+    github.send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
     assert result is True
 
 def test_delete_pr_comment_failed_request(mocker, github):
-    mocker.patch.object(github, "_send_request", return_value=None)
+    mocker.patch.object(github, "send_request", return_value=None)
 
     result = github.delete_comment(123)
 
-    github._send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
+    github.send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
     assert result is False
 
 def test_delete_pr_comment_unexpected_response(mocker, github):
     mock_response = mocker.Mock()
     mock_response.status_code = 400  # HTTP 400 Bad Request
-    mocker.patch.object(github, "_send_request", return_value=mock_response)
+    mocker.patch.object(github, "send_request", return_value=mock_response)
 
     result = github.delete_comment(123)
 
-    github._send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
+    github.send_request.assert_called_once_with("DELETE", "https://api.github.com/repos/fake_repo/issues/comments/123")
     assert result is False


### PR DESCRIPTION
## Overview

Tests were directly accessing private members (`_review_violations`, `_evaluate_module`,
`_send_request`, `_scan_jacoco_xml_files`, `_get_basic_table`,
`_generate_changed_files_table_*`, `_calculate_baseline_module_diffs`,
`_global_min_coverage_*`, `_changed_files`) via the single-underscore convention.
This couples tests to internal implementation details and bypasses Python's intended
encapsulation signal.

The fix promotes the relevant methods to public (removing the leading `_`) across four
source modules, and refactors two tests that were mutating private attributes to instead
construct objects with the correct state from the start.

Release Notes:

- No user-facing behaviour change; internal refactor only.
