### PR TITLE
feat: expand comment-level options and update documentation for PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Each entry is a YAML mapping with:
 ##### No Comment
 
 - When the `comment-level` is set to `none`, no PR comment is posted.
+- If `update-comment: true` and a previous JaCoCo comment with the same title exists, that stale comment is deleted.
 
 ##### Minimal Level
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
 | `title`             | Title for the coverage report comment added to the Pull Request.                                                                                                                                                               | No       | `JaCoCo Coverage Report`                         |
 | `pr-number`         | Number of the pull request. If not provided, the action will attempt to determine <br> the PR number from the GitHub context.                                                                                                  | No       | `''`                                             |
 | `metric`            | Coverage metric to use (`instruction`, `line`, `branch`, `complexity`, `method`, `class`).                                                                                                                                     | No       | `instruction`                                    |
-| `comment-level`     | Detail level of the PR comment (`minimal`, `full`).                                                                                                                                                                            | No       | `full`                                           |
+| `comment-level`     | Comment output level: `none`, `minimal`, `full`, `changed`, `failed`, or `failed-or-changed`. `changed`, `failed`, and `failed-or-changed` keep the global summary table and filter lower tables by row.                     | No       | `full`                                           |
 | `report-groups`     | Named report groups as a YAML list. Each entry: `name` (required), `paths` (required list of globs), `thresholds` (optional `O*A*P`, e.g. `80*70*60`), `baseline-paths` (optional list). When set, group `paths` are used. | No       | `''`                                             |
 | `skip-unchanged`    | If `true`, skips entire reports with no changed files in the PR, reducing comment noise.                                                                                                                                       | No       | `false`                                          |
 | `baseline-paths`    | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.                                                                                                                                            | No       | `''`                                             |
@@ -98,8 +98,12 @@ threshold.
 - [Customizing the Report Title](#customizing-the-report-title)
 - [Customizing the Report Groups](#customizing-the-report-groups)
 - [Customizing the Comment Level](#customizing-the-comment-level)
+  - [No Comment](#no-comment)
   - [Minimal Level](#minimal-level)
   - [Full Level](#full-level)
+  - [Changed Level](#changed-level)
+  - [Failed Level](#failed-level)
+  - [Failed-or-Changed Level](#failed-or-changed-level)
 - [Customizing the Skip Unchanged Option and Update Comment](#customizing-the-skip-unchanged-option-and-update-comment)
 - [Customizing the Baseline Paths](#customizing-the-baseline-paths)
 - [Customizing the Symbols and Metric Type](#customizing-the-symbols-and-metric-type)
@@ -232,6 +236,10 @@ Each entry is a YAML mapping with:
 
 #### Customizing the Comment Level
 
+##### No Comment
+
+- When the `comment-level` is set to `none`, no PR comment is posted.
+
 ##### Minimal Level
 
 - When the `comment-level` is set to `minimal`, one comment is added to the pull request representing the overall and
@@ -277,11 +285,22 @@ changed files coverage for all detected report files.
 > - The groups table is visible when `report-groups` is defined.
 > - `global-thresholds` is always evaluated independently as a separate pass over aggregated totals and is never part of the group fallback chain.
 
+##### Changed Level
+
+- When the `comment-level` is set to `changed`, the global summary table is kept and only group, report, and file rows with changed files are shown.
+
+##### Failed Level
+
+- When the `comment-level` is set to `failed`, the global summary table is kept and only rows failing their threshold are shown.
+
+##### Failed-or-Changed Level
+
+- When the `comment-level` is set to `failed-or-changed`, the global summary table is kept and rows are shown when they either have changed files or fail a threshold.
+
 #### Customizing the Skip Unchanged Option and Update Comment
 
-The `skip-unchanged` input, when set to true, optimizes JaCoCo-related comments by focusing only on relevant changes
-in the pull request. It removes unchanged lines from the modules table and reduces the number of generated comments by
-skipping entire modules and reports with no modified files.
+The `skip-unchanged` input, when set to true, filters reports with no changed files before evaluation and comment
+generation. This reduces comment noise by removing unchanged reports entirely.
 
 The `update-comment` input, when set to true, updates an existing comment with the latest coverage data instead of
 creating a new comment.

--- a/TASKS.md
+++ b/TASKS.md
@@ -69,7 +69,7 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **27** | G | Implement `skip-unchanged` scan-stage filter | ✅ | `feature/112-Update-logic-for-input-skip_unchanged` | #112 |
 | **28** | G | Implement `report-groups` YAML input | ✅ | `feature/108-report-groups-yaml-input` | #108 |
 | **29** | G | Add `report-thresholds-default` input | ✅ | `feature/113-report-thresholds-default` | #113 |
-| **30** | G | Expand `comment-level` full option set | 🔒 ⬜ | `feature/102-comment-level-full-option-set` | #102 |
+| **30** | G | Expand `comment-level` full option set | ✅ | `feature/102-comment-level-full-option-set` | #102 |
 | **31** | G | `fail-on-threshold` boolean deprecation impl | 🔒 ⬜ | `feature/103-fail-on-threshold-deprecation-evaluate-unchanged` | #103 |
 | **32** | H | Integration test helpers module | 🔒 ⬜ | `chore/integration-test-helpers` | new |
 | **33** | H | Golden snapshot tests | 🔒 ⬜ | `chore/golden-snapshot-tests` | new |

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: 'instruction'
   comment-level:
-    description: 'Level of the comment.'
+    description: 'Comment output level: none, minimal, full, changed, failed, or failed-or-changed.'
     required: false
     default: 'full'
   report-groups:

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -597,7 +597,10 @@ class ActionInputs:
 
         comment_level = ActionInputs.get_comment_level()
         if not isinstance(comment_level, str) or comment_level not in CommentLevelEnum:
-            errors.append("'comment-level' must be a string from these options: 'minimal', 'full'.")
+            errors.append(
+                "'comment-level' must be a string from these options: "
+                "'none', 'minimal', 'full', 'changed', 'failed', 'failed-or-changed'."
+            )
 
         errors.extend(ActionInputs.validate_report_groups(report_groups_raw))
 

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -40,6 +40,8 @@ class PRCommentGenerator:
         The method that generates the comment for a single generator.
         """
         title, pr_body = self._get_comment_content()
+        if ActionInputs.get_comment_level() == CommentLevelEnum.NONE:
+            return
 
         # Get all comments on the pull request
         comments = self.gh.get_comments(self.pr_number)
@@ -57,27 +59,97 @@ class PRCommentGenerator:
             self.gh.add_comment(self.pr_number, pr_body)
 
     def _get_comment_content(self) -> tuple[str, str]:
+        """Build the PR comment title and body for the selected comment level."""
         title = body = f"**{ActionInputs.get_title()}**"
+        comment_level = ActionInputs.get_comment_level()
+
+        if comment_level == CommentLevelEnum.NONE:
+            return title, body
 
         p = ActionInputs.get_pass_symbol()
         f = ActionInputs.get_fail_symbol()
 
         body += f"\n\n{self.get_basic_table_for_all(p, f)}"
 
-        if ActionInputs.get_comment_level() == CommentLevelEnum.FULL:
-            groups_table = self.get_groups_table(p, f)
-            if groups_table:
-                body += f"\n\n{groups_table}"
+        if comment_level == CommentLevelEnum.MINIMAL:
+            return title, body
 
-            reports_table = self.get_reports_table(p, f)
-            if reports_table != "":
-                body += f"\n\n{reports_table}"
+        filtered_groups = self.evaluator.evaluated_groups_coverage
+        filtered_reports = self.evaluator.evaluated_reports_coverage
 
-            body += f"\n\n{self._get_changed_files_table(p, f)}"
+        if comment_level != CommentLevelEnum.FULL:
+            filtered_groups = self._filter_evaluated_coverage_rows(filtered_groups, comment_level)
+            filtered_reports = self._filter_evaluated_coverage_rows(filtered_reports, comment_level)
+
+        detail_sections: list[str] = []
+
+        groups_table = self.get_groups_table(p, f, filtered_groups)
+        if groups_table:
+            detail_sections.append(groups_table)
+
+        reports_table = self.get_reports_table(p, f, filtered_reports)
+        if reports_table:
+            detail_sections.append(reports_table)
+
+        changed_files_table = self._get_changed_files_table(p, f, filtered_reports, comment_level)
+        if changed_files_table:
+            detail_sections.append(changed_files_table)
+
+        if detail_sections:
+            body += "\n\n" + "\n\n".join(detail_sections)
+        elif comment_level != CommentLevelEnum.FULL:
+            body += "\n\nNo rows match the selected comment level."
 
         return title, body
 
+    def _filter_evaluated_coverage_rows(
+        self,
+        evaluated_coverages: dict[str, EvaluatedReportCoverage],
+        comment_level: str,
+    ) -> dict[str, EvaluatedReportCoverage]:
+        """Filter group or report rows according to the selected comment level."""
+        return {
+            key: coverage
+            for key, coverage in evaluated_coverages.items()
+            if self._should_include_coverage_row(coverage, comment_level)
+        }
+
+    def _should_include_coverage_row(self, coverage: EvaluatedReportCoverage, comment_level: str) -> bool:
+        """Return whether one evaluated group or report row should be rendered."""
+        if comment_level == CommentLevelEnum.FULL:
+            return True
+
+        has_changed_files = self._has_changed_files(coverage)
+        is_failing = self._is_failing_coverage(coverage)
+
+        if comment_level == CommentLevelEnum.CHANGED:
+            return has_changed_files
+
+        if comment_level == CommentLevelEnum.FAILED:
+            return is_failing
+
+        if comment_level == CommentLevelEnum.FAILED_OR_CHANGED:
+            return has_changed_files or is_failing
+
+        return False
+
+    def _has_changed_files(self, coverage: EvaluatedReportCoverage) -> bool:
+        """Return whether a coverage row represents at least one changed file."""
+        if coverage.changed_files_coverage_reached:
+            return True
+
+        return (coverage.avg_changed_files_coverage.covered + coverage.avg_changed_files_coverage.missed) > 0
+
+    def _is_failing_coverage(self, coverage: EvaluatedReportCoverage) -> bool:
+        """Return whether any threshold represented by the coverage row is failing."""
+        return (
+            not coverage.overall_passed
+            or not coverage.avg_changed_files_passed
+            or any(not passed for passed in coverage.changed_files_passed.values())
+        )
+
     def _has_baseline_data(self) -> bool:
+        """Return whether baseline evaluator data is available for diff columns."""
         if not self.bs_evaluator:
             return False
 
@@ -90,6 +162,7 @@ class PRCommentGenerator:
         return has_report_baseline or has_group_baseline
 
     def get_basic_table_for_all(self, p: str, f: str) -> str:
+        """Render the global summary table, with baseline deltas when available."""
         if not self._has_baseline_data():
             return self.get_basic_table(
                 p,
@@ -135,13 +208,16 @@ class PRCommentGenerator:
         total_changed_files_passed: bool,
         min_changed_files: float,
     ) -> str:
+        """Render the global summary table without baseline deltas."""
         return (
-            dedent("""
+            dedent(
+                """
             | Metric ({}) | Coverage | Threshold | Status |
             |----------------------|----------|-----------|--------|
             | **Overall**       | {}% | {}% | {} |
             | **Changed Files** | {}% | {}% | {} |
-        """)
+        """
+            )
             .strip()
             .format(
                 metric,
@@ -168,16 +244,19 @@ class PRCommentGenerator:
         bs_total_overall_reached: float,
         bs_total_changed_files_reached: float,
     ) -> str:
+        """Render the global summary table with baseline delta columns."""
         diff_o = total_overall_reached - bs_total_overall_reached
         diff_ch = total_changed_files_reached - bs_total_changed_files_reached
 
         return (
-            dedent("""
+            dedent(
+                """
             | Metric ({}) | Coverage | Threshold | Δ Coverage | Status |
             |-------------------|-----|-----|-----|----|
             | **Overall**       | {}% | {}% | {}{}% | {} |
             | **Changed Files** | {}% | {}% | {}{}% | {} |
-        """)
+        """
+            )
             .strip()
             .format(
                 metric,
@@ -194,28 +273,41 @@ class PRCommentGenerator:
             )
         )
 
-    def get_groups_table(self, p: str, f: str) -> str:
-        if not self.evaluator.evaluated_groups_coverage:
+    def get_groups_table(
+        self,
+        p: str,
+        f: str,
+        evaluated_groups_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None,
+    ) -> str:
+        """Render the groups table for the provided evaluated group rows."""
+        if evaluated_groups_coverage is None:
+            evaluated_groups_coverage = self.evaluator.evaluated_groups_coverage
+
+        if not evaluated_groups_coverage:
             return ""
 
         has_baseline = self._has_baseline_data()
 
         if not has_baseline:
-            s = dedent("""
+            s = dedent(
+                """
                 | Group | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
                 |-------|----------|-----------|--------|
-            """).strip()
-            for group_name, ev in sorted(self.evaluator.evaluated_groups_coverage.items()):
+            """
+            ).strip()
+            for group_name, ev in sorted(evaluated_groups_coverage.items()):
                 cov = f"{ev.overall_coverage_reached}% / {ev.avg_changed_files_coverage_reached}%"
                 thres = f"{ev.overall_coverage_threshold}% / {ev.changed_files_threshold}%"
                 status = f"{p if ev.overall_passed else f}/{p if ev.avg_changed_files_passed else f}"
                 s += f"\n| `{group_name}` | {cov} | {thres} | {status} |"
         else:
-            s = dedent("""
+            s = dedent(
+                """
                 | Group | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |
                 |-------|----------|-----------|------------|--------|
-            """).strip()
-            for group_name, ev in sorted(self.evaluator.evaluated_groups_coverage.items()):
+            """
+            ).strip()
+            for group_name, ev in sorted(evaluated_groups_coverage.items()):
                 diff_o, diff_ch = self.calculate_baseline_group_diffs(ev)
                 diff_o = round(diff_o, 2)
                 diff_ch = round(diff_ch, 2)
@@ -226,22 +318,41 @@ class PRCommentGenerator:
                 s += f"\n| `{group_name}` | {cov} | {thres} | {delta} | {status} |"
         return s
 
-    def get_reports_table(self, p: str, f: str) -> str:
+    def get_reports_table(
+        self,
+        p: str,
+        f: str,
+        evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None,
+    ) -> str:
+        """Render the reports table for the provided evaluated report rows."""
         if not self._has_baseline_data():
-            return self._generate_reports_table_without_baseline(p, f)
+            return self._generate_reports_table_without_baseline(p, f, evaluated_reports_coverage)
 
-        return self._generate_reports_table_with_baseline(p, f)
+        return self._generate_reports_table_with_baseline(p, f, evaluated_reports_coverage)
 
-    def _generate_reports_table_without_baseline(self, p: str, f: str, **kwargs) -> str:
-        s = dedent("""
+    def _generate_reports_table_without_baseline(
+        self,
+        p: str,
+        f: str,
+        evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None,
+    ) -> str:
+        if evaluated_reports_coverage is None:
+            evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage
+
+        if not evaluated_reports_coverage:
+            return ""
+
+        s = dedent(
+            """
             | Report | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
             |--------|----------|-----------|--------|
-        """).strip()
+        """
+        ).strip()
 
         provided_reports = 0
-        keys: list[str] = sorted(list(self.evaluator.evaluated_reports_coverage.keys()))
+        keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
-            evaluated_report = self.evaluator.evaluated_reports_coverage[key]
+            evaluated_report = evaluated_reports_coverage[key]
             provided_reports += 1
             o_thres = evaluated_report.overall_coverage_threshold
             ch_thres = evaluated_report.changed_files_threshold
@@ -259,16 +370,29 @@ class PRCommentGenerator:
 
         return s
 
-    def _generate_reports_table_with_baseline(self, p: str, f: str, **kwargs) -> str:
-        s = dedent("""
+    def _generate_reports_table_with_baseline(
+        self,
+        p: str,
+        f: str,
+        evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None,
+    ) -> str:
+        if evaluated_reports_coverage is None:
+            evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage
+
+        if not evaluated_reports_coverage:
+            return ""
+
+        s = dedent(
+            """
             | Report | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |
             |--------|----------|-----------|------------|--------|
-        """).strip()
+        """
+        ).strip()
 
         provided_reports = 0
-        keys: list[str] = sorted(list(self.evaluator.evaluated_reports_coverage.keys()))
+        keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
-            evaluated_report = self.evaluator.evaluated_reports_coverage[key]
+            evaluated_report = evaluated_reports_coverage[key]
 
             provided_reports += 1
             diff_o, diff_ch = self._calculate_baseline_report_diffs(evaluated_report)
@@ -294,6 +418,7 @@ class PRCommentGenerator:
         return s
 
     def calculate_baseline_group_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
+        """Calculate baseline deltas for one rendered group row."""
         if evaluated_coverage.name not in self.bs_evaluator.evaluated_groups_coverage.keys():
             return 0.0, 0.0
 
@@ -315,6 +440,7 @@ class PRCommentGenerator:
         return diff_o, diff_ch
 
     def _calculate_baseline_report_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
+        """Calculate baseline deltas for one rendered report row."""
         if evaluated_coverage.name not in self.bs_evaluator.evaluated_reports_coverage.keys():
             return 0.0, 0.0
 
@@ -342,10 +468,12 @@ class PRCommentGenerator:
         """
         Generate a table with changed files without baseline. The table contains the files from all reports.
         """
-        s = dedent("""
+        s = dedent(
+            """
             | File Path | Coverage | Threshold | Status |
             |-----------|----------|-----------|--------|
-        """).strip()
+        """
+        ).strip()
 
         if evaluated_reports_coverage is None:
             evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage
@@ -375,22 +503,74 @@ class PRCommentGenerator:
 
         return s
 
-    def _get_changed_files_table(self, p: str, f: str) -> str:
-        if len(self.evaluator.evaluated_reports_coverage.keys()) == 0:
-            return "\nNo changed file in reports."
+    def _get_changed_files_table(
+        self,
+        p: str,
+        f: str,
+        evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None,
+        comment_level: str = CommentLevelEnum.FULL,
+    ) -> str:
+        """Render the changed-files table after applying any file-level filters."""
+        if evaluated_reports_coverage is None:
+            evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage
+
+        if not evaluated_reports_coverage:
+            return ""
+
+        if comment_level == CommentLevelEnum.FAILED:
+            evaluated_reports_coverage = self._filter_reports_for_failed_files(evaluated_reports_coverage)
+
+        if not evaluated_reports_coverage:
+            return ""
 
         if not self._has_baseline_data():
-            return self.generate_changed_files_table_without_baseline(p, f)
+            return self.generate_changed_files_table_without_baseline(p, f, evaluated_reports_coverage)
 
-        return self.generate_changed_files_table_with_baseline(p, f)
+        return self.generate_changed_files_table_with_baseline(p, f, evaluated_reports_coverage)
+
+    def _filter_reports_for_failed_files(
+        self,
+        evaluated_reports_coverage: dict[str, EvaluatedReportCoverage],
+    ) -> dict[str, EvaluatedReportCoverage]:
+        """Keep only failing changed-file rows while preserving report metadata."""
+        filtered_reports: dict[str, EvaluatedReportCoverage] = {}
+        for key, coverage in evaluated_reports_coverage.items():
+            failed_files = {
+                file_path: score
+                for file_path, score in coverage.changed_files_coverage_reached.items()
+                if not coverage.changed_files_passed.get(file_path, True)
+            }
+            if not failed_files:
+                continue
+
+            filtered_coverage = EvaluatedReportCoverage(coverage.name, coverage.group_name)
+            filtered_coverage.overall_passed = coverage.overall_passed
+            filtered_coverage.avg_changed_files_passed = coverage.avg_changed_files_passed
+            filtered_coverage.overall_coverage_reached = coverage.overall_coverage_reached
+            filtered_coverage.avg_changed_files_coverage_reached = coverage.avg_changed_files_coverage_reached
+            filtered_coverage.overall_coverage_threshold = coverage.overall_coverage_threshold
+            filtered_coverage.changed_files_threshold = coverage.changed_files_threshold
+            filtered_coverage.per_changed_file_threshold = coverage.per_changed_file_threshold
+            filtered_coverage.overall_coverage = coverage.overall_coverage
+            filtered_coverage.avg_changed_files_coverage = coverage.avg_changed_files_coverage
+            filtered_coverage.changed_files_coverage_reached = failed_files
+            filtered_coverage.changed_files_passed = {
+                file_path: coverage.changed_files_passed[file_path] for file_path in failed_files
+            }
+            filtered_reports[key] = filtered_coverage
+
+        return filtered_reports
 
     def generate_changed_files_table_with_baseline(
         self, p: str, f: str, evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None
     ) -> str:
-        s = dedent("""
+        """Generate a changed-files table that includes baseline deltas."""
+        s = dedent(
+            """
             | File Path | Coverage | Threshold | Δ Coverage | Status |
             |-----------|----------|-----------|------------|--------|
-        """).strip()
+        """
+        ).strip()
 
         if evaluated_reports_coverage is None:
             evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -353,11 +353,9 @@ class PRCommentGenerator:
         """
         ).strip()
 
-        provided_reports = 0
         keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
             evaluated_report = evaluated_reports_coverage[key]
-            provided_reports += 1
             o_thres = evaluated_report.overall_coverage_threshold
             ch_thres = evaluated_report.changed_files_threshold
 
@@ -368,9 +366,6 @@ class PRCommentGenerator:
             status_o = p if evaluated_report.overall_passed else f
             status_ch = p if evaluated_report.avg_changed_files_passed else f
             s += f"\n| `{name}` | {cov} | {thres} | {status_o}/{status_ch} |"
-
-        if provided_reports == 0:
-            s += "\n\nNo changed file in reports."
 
         return s
 
@@ -393,12 +388,9 @@ class PRCommentGenerator:
         """
         ).strip()
 
-        provided_reports = 0
         keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
             evaluated_report = evaluated_reports_coverage[key]
-
-            provided_reports += 1
             diff_o, diff_ch = self._calculate_baseline_report_diffs(evaluated_report)
 
             o_thres = evaluated_report.overall_coverage_threshold
@@ -415,9 +407,6 @@ class PRCommentGenerator:
             status_o = p if evaluated_report.overall_passed else f
             status_ch = p if evaluated_report.avg_changed_files_passed else f
             s += f"\n| `{name}` | {cov} | {thres} | {delta} | {status_o}/{status_ch} |"
-
-        if provided_reports == 0:
-            s += "\n\nNo changed file in reports."
 
         return s
 

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -42,6 +42,10 @@ class PRCommentGenerator:
         comment_level = ActionInputs.get_comment_level()
         update_comment = ActionInputs.get_update_comment()
 
+        # No comment operation is needed in this mode, so skip the API read call entirely.
+        if comment_level == CommentLevelEnum.NONE and not update_comment:
+            return
+
         title, pr_body = self._get_comment_content(comment_level)
         # Get all comments on the pull request
         comments = self.gh.get_comments(self.pr_number)

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -40,9 +40,6 @@ class PRCommentGenerator:
         The method that generates the comment for a single generator.
         """
         title, pr_body = self._get_comment_content()
-        if ActionInputs.get_comment_level() == CommentLevelEnum.NONE:
-            return
-
         # Get all comments on the pull request
         comments = self.gh.get_comments(self.pr_number)
 
@@ -52,6 +49,11 @@ class PRCommentGenerator:
             if len(title) > 0 and comment["body"].startswith(title):  # Detects if it starts with the title
                 existing_comment = comment
                 break
+
+        if ActionInputs.get_comment_level() == CommentLevelEnum.NONE:
+            if existing_comment and ActionInputs.get_update_comment():
+                self.gh.delete_comment(existing_comment["id"])
+            return
 
         if existing_comment and ActionInputs.get_update_comment():
             self.gh.update_comment(existing_comment["id"], pr_body)

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -39,7 +39,10 @@ class PRCommentGenerator:
         """
         The method that generates the comment for a single generator.
         """
-        title, pr_body = self._get_comment_content()
+        comment_level = ActionInputs.get_comment_level()
+        update_comment = ActionInputs.get_update_comment()
+
+        title, pr_body = self._get_comment_content(comment_level)
         # Get all comments on the pull request
         comments = self.gh.get_comments(self.pr_number)
 
@@ -50,20 +53,19 @@ class PRCommentGenerator:
                 existing_comment = comment
                 break
 
-        if ActionInputs.get_comment_level() == CommentLevelEnum.NONE:
-            if existing_comment and ActionInputs.get_update_comment():
+        if comment_level == CommentLevelEnum.NONE:
+            if existing_comment and update_comment:
                 self.gh.delete_comment(existing_comment["id"])
             return
 
-        if existing_comment and ActionInputs.get_update_comment():
+        if existing_comment and update_comment:
             self.gh.update_comment(existing_comment["id"], pr_body)
         else:
             self.gh.add_comment(self.pr_number, pr_body)
 
-    def _get_comment_content(self) -> tuple[str, str]:
+    def _get_comment_content(self, comment_level: str) -> tuple[str, str]:
         """Build the PR comment title and body for the selected comment level."""
         title = body = f"**{ActionInputs.get_title()}**"
-        comment_level = ActionInputs.get_comment_level()
 
         if comment_level == CommentLevelEnum.NONE:
             return title, body
@@ -545,16 +547,7 @@ class PRCommentGenerator:
             if not failed_files:
                 continue
 
-            filtered_coverage = EvaluatedReportCoverage(coverage.name, coverage.group_name)
-            filtered_coverage.overall_passed = coverage.overall_passed
-            filtered_coverage.avg_changed_files_passed = coverage.avg_changed_files_passed
-            filtered_coverage.overall_coverage_reached = coverage.overall_coverage_reached
-            filtered_coverage.avg_changed_files_coverage_reached = coverage.avg_changed_files_coverage_reached
-            filtered_coverage.overall_coverage_threshold = coverage.overall_coverage_threshold
-            filtered_coverage.changed_files_threshold = coverage.changed_files_threshold
-            filtered_coverage.per_changed_file_threshold = coverage.per_changed_file_threshold
-            filtered_coverage.overall_coverage = coverage.overall_coverage
-            filtered_coverage.avg_changed_files_coverage = coverage.avg_changed_files_coverage
+            filtered_coverage = coverage.clone()
             filtered_coverage.changed_files_coverage_reached = failed_files
             filtered_coverage.changed_files_passed = {
                 file_path: coverage.changed_files_passed[file_path] for file_path in failed_files

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -52,3 +52,24 @@ class EvaluatedReportCoverage:
             "changed_files_coverage_reached": self.changed_files_coverage_reached,
             "per_changed_file_threshold": self.per_changed_file_threshold,
         }
+
+    def clone(self) -> "EvaluatedReportCoverage":
+        """Return a detached copy of the evaluated coverage object."""
+        clone = EvaluatedReportCoverage(self.name, self.group_name)
+        clone.overall_passed = self.overall_passed
+        clone.overall_coverage_reached = self.overall_coverage_reached
+        clone.overall_coverage_threshold = self.overall_coverage_threshold
+        clone.overall_coverage = Counter(self.overall_coverage.missed, self.overall_coverage.covered)
+
+        clone.avg_changed_files_passed = self.avg_changed_files_passed
+        clone.avg_changed_files_coverage_reached = self.avg_changed_files_coverage_reached
+        clone.avg_changed_files_coverage = Counter(
+            self.avg_changed_files_coverage.missed,
+            self.avg_changed_files_coverage.covered,
+        )
+
+        clone.changed_files_passed = dict(self.changed_files_passed)
+        clone.changed_files_threshold = self.changed_files_threshold
+        clone.changed_files_coverage_reached = dict(self.changed_files_coverage_reached)
+        clone.per_changed_file_threshold = self.per_changed_file_threshold
+        return clone

--- a/jacoco_report/utils/enums.py
+++ b/jacoco_report/utils/enums.py
@@ -10,8 +10,12 @@ class CommentLevelEnum(StrEnum):
     A class representing the comment mode enum.
     """
 
+    NONE = "none"
     MINIMAL = "minimal"
     FULL = "full"
+    CHANGED = "changed"
+    FAILED = "failed"
+    FAILED_OR_CHANGED = "failed-or-changed"
 
 
 class MetricTypeEnum(StrEnum):

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -536,7 +536,7 @@ def test_generate_skips_github_comment_for_none(pr_comment_generator, mocker):
 
     pr_comment_generator.generate()
 
-    pr_comment_generator.gh.get_comments.assert_called_once_with(1)
+    pr_comment_generator.gh.get_comments.assert_not_called()
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
 
@@ -548,6 +548,7 @@ def test_none_deletes_existing_comment_when_update_comment_enabled(pr_comment_ge
 
     pr_comment_generator.generate()
 
+    pr_comment_generator.gh.get_comments.assert_called_once_with(1)
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
     pr_comment_generator.gh.delete_comment.assert_called_once_with(123)
@@ -560,6 +561,7 @@ def test_none_leaves_existing_comment_when_update_comment_disabled(pr_comment_ge
 
     pr_comment_generator.generate()
 
+    pr_comment_generator.gh.get_comments.assert_not_called()
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
     pr_comment_generator.gh.delete_comment.assert_not_called()

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -536,6 +536,7 @@ def test_generate_skips_github_comment_for_none(pr_comment_generator, mocker):
 
     pr_comment_generator.generate()
 
+    pr_comment_generator.gh.get_comments.assert_called_once_with(1)
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
 
@@ -562,20 +563,6 @@ def test_none_leaves_existing_comment_when_update_comment_disabled(pr_comment_ge
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
     pr_comment_generator.gh.delete_comment.assert_not_called()
-
-
-def test_none_comment_content_is_title_only(pr_comment_generator, mocker):
-    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
-    _set_mixed_comment_level_fixture(pr_comment_generator)
-
-    title, body = pr_comment_generator._get_comment_content()
-
-    assert title == "**JaCoCo**"
-    assert body == "**JaCoCo**"
-    assert "| Metric (instruction) |" not in body
-    assert "| Group |" not in body
-    assert "| Report |" not in body
-    assert "| File Path |" not in body
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -71,6 +71,25 @@ def _configure_generator_for_comment_tests(generator, mocker, *, comment_level):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="owner/repo")
     generator.gh.get_comments.return_value = []
 
+
+def _set_mixed_comment_level_fixture(pr_comment_generator):
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "changed-group": _make_evaluated_coverage("changed-group", changed_files={"src/Foo.java": 82.0}),
+        "failing-group": _make_evaluated_coverage("failing-group", overall_passed=False, changed_files={}),
+        "unchanged-group": _make_evaluated_coverage("unchanged-group", changed_files={}),
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "changed-report": _make_evaluated_coverage("changed-report", changed_files={"src/Foo.java": 82.0}),
+        "failing-report": _make_evaluated_coverage(
+            "failing-report",
+            overall_passed=False,
+            changed_passed=False,
+            changed_files={"src/Bar.java": 60.0},
+            changed_threshold=80.0,
+        ),
+        "unchanged-report": _make_evaluated_coverage("unchanged-report", changed_files={}),
+    }
+
 def testget_basic_table(pr_comment_generator, mocker):
     table = pr_comment_generator.get_basic_table(
         "✅", "❌", MetricTypeEnum.INSTRUCTION,
@@ -521,7 +540,7 @@ def test_generate_skips_github_comment_for_none(pr_comment_generator, mocker):
     pr_comment_generator.gh.update_comment.assert_not_called()
 
 
-def test_none_keeps_existing_comment_untouched(pr_comment_generator, mocker):
+def test_none_deletes_existing_comment_when_update_comment_enabled(pr_comment_generator, mocker):
     _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
     pr_comment_generator.gh.get_comments.return_value = [{"id": 123, "body": "**JaCoCo**\n\nold body"}]
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=True)
@@ -530,7 +549,95 @@ def test_none_keeps_existing_comment_untouched(pr_comment_generator, mocker):
 
     pr_comment_generator.gh.add_comment.assert_not_called()
     pr_comment_generator.gh.update_comment.assert_not_called()
+    pr_comment_generator.gh.delete_comment.assert_called_once_with(123)
+
+
+def test_none_leaves_existing_comment_when_update_comment_disabled(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
+    pr_comment_generator.gh.get_comments.return_value = [{"id": 123, "body": "**JaCoCo**\n\nold body"}]
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=False)
+
+    pr_comment_generator.generate()
+
+    pr_comment_generator.gh.add_comment.assert_not_called()
+    pr_comment_generator.gh.update_comment.assert_not_called()
     pr_comment_generator.gh.delete_comment.assert_not_called()
+
+
+def test_none_comment_content_is_title_only(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
+    _set_mixed_comment_level_fixture(pr_comment_generator)
+
+    title, body = pr_comment_generator._get_comment_content()
+
+    assert title == "**JaCoCo**"
+    assert body == "**JaCoCo**"
+    assert "| Metric (instruction) |" not in body
+    assert "| Group |" not in body
+    assert "| Report |" not in body
+    assert "| File Path |" not in body
+
+
+@pytest.mark.parametrize(
+    ("comment_level", "expected_fragments", "absent_fragments"),
+    [
+        (
+            "minimal",
+            ["| Metric (instruction) |"],
+            ["| Group |", "| Report |", "| File Path |", "`changed-group`", "[Foo.java]"],
+        ),
+        (
+            "full",
+            [
+                "| Metric (instruction) |",
+                "| Group |",
+                "| Report |",
+                "| File Path |",
+                "`changed-group`",
+                "`failing-group`",
+                "`unchanged-group`",
+                "`changed-report`",
+                "`failing-report`",
+                "`unchanged-report`",
+                "[Foo.java]",
+                "[Bar.java]",
+            ],
+            [],
+        ),
+        (
+            "changed",
+            ["| Metric (instruction) |", "| Group |", "| Report |", "| File Path |", "`changed-group`", "`changed-report`", "`failing-report`", "[Foo.java]", "[Bar.java]"],
+            ["`unchanged-group`", "`unchanged-report`", "`failing-group`"],
+        ),
+        (
+            "failed",
+            ["| Metric (instruction) |", "| Group |", "| Report |", "| File Path |", "`failing-group`", "`failing-report`", "[Bar.java]"],
+            ["`changed-group`", "`changed-report`", "`unchanged-group`", "`unchanged-report`", "[Foo.java]"],
+        ),
+        (
+            "failed-or-changed",
+            ["| Metric (instruction) |", "| Group |", "| Report |", "| File Path |", "`changed-group`", "`failing-group`", "`changed-report`", "`failing-report`", "[Foo.java]", "[Bar.java]"],
+            ["`unchanged-group`", "`unchanged-report`"],
+        ),
+    ],
+)
+def test_comment_level_final_pr_body_matrix(
+    pr_comment_generator,
+    mocker,
+    comment_level,
+    expected_fragments,
+    absent_fragments,
+):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level=comment_level)
+    _set_mixed_comment_level_fixture(pr_comment_generator)
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    for fragment in expected_fragments:
+        assert fragment in body
+    for fragment in absent_fragments:
+        assert fragment not in body
 
 
 def test_full_comment_contains_all_tables(pr_comment_generator, mocker):
@@ -658,3 +765,27 @@ def test_filtered_comment_levels_handle_empty_result_gracefully(pr_comment_gener
     assert "No rows match the selected comment level." in body
     assert "`hidden-group`" not in body
     assert "`hidden-report`" not in body
+
+
+@pytest.mark.parametrize("comment_level", ["changed", "failed", "failed-or-changed"])
+def test_filtered_comment_levels_empty_result_do_not_render_detail_table_headers(
+    pr_comment_generator,
+    mocker,
+    comment_level,
+):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level=comment_level)
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "hidden-group": _make_evaluated_coverage("hidden-group", changed_files={})
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "hidden-report": _make_evaluated_coverage("hidden-report", changed_files={})
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "| Metric (instruction) |" in body
+    assert "No rows match the selected comment level." in body
+    assert "| Group |" not in body
+    assert "| Report |" not in body
+    assert "| File Path |" not in body

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -2,6 +2,7 @@ import pytest
 
 from jacoco_report.evaluator.coverage_evaluator import CoverageEvaluator
 from jacoco_report.generator.pr_comment_generator import PRCommentGenerator
+from jacoco_report.model.counter import Counter
 from jacoco_report.model.evaluated_report_coverage import EvaluatedReportCoverage
 from jacoco_report.utils.enums import MetricTypeEnum
 
@@ -27,6 +28,48 @@ def test_evaluator(mocker):
 @pytest.fixture
 def pr_comment_generator(mock_github, test_evaluator):
     return PRCommentGenerator(mock_github, test_evaluator, None, 1)
+
+
+def _make_evaluated_coverage(
+    name,
+    *,
+    group_name="Unknown",
+    overall_passed=True,
+    changed_passed=True,
+    overall_coverage=85.0,
+    changed_coverage=80.0,
+    overall_threshold=75.0,
+    changed_threshold=70.0,
+    changed_files=None,
+):
+    coverage = EvaluatedReportCoverage(name, group_name=group_name)
+    coverage.overall_passed = overall_passed
+    coverage.avg_changed_files_passed = changed_passed
+    coverage.overall_coverage_reached = overall_coverage
+    coverage.avg_changed_files_coverage_reached = changed_coverage
+    coverage.overall_coverage_threshold = overall_threshold
+    coverage.changed_files_threshold = changed_threshold
+    coverage.per_changed_file_threshold = changed_threshold
+    coverage.avg_changed_files_coverage = Counter(0, len(changed_files or {}))
+    coverage.changed_files_coverage_reached = changed_files or {}
+    coverage.changed_files_passed = {
+        path: changed_passed if score >= changed_threshold else False
+        for path, score in (changed_files or {}).items()
+    }
+    return coverage
+
+
+def _configure_generator_for_comment_tests(generator, mocker, *, comment_level):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value=comment_level)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_title", return_value="JaCoCo")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_pass_symbol", return_value="✅")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_fail_symbol", return_value="❌")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_overall_threshold", return_value=80.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_changed_files_average_threshold", return_value=80.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=False)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="owner/repo")
+    generator.gh.get_comments.return_value = []
 
 def testget_basic_table(pr_comment_generator, mocker):
     table = pr_comment_generator.get_basic_table(
@@ -465,3 +508,153 @@ def test_calculate_baseline_group_diffs_no_data_returns_zero(pr_comment_generato
 
     assert diff_o == 0.0
     assert diff_ch == 0.0
+
+
+# --- comment-level expansion ---
+
+def test_generate_skips_github_comment_for_none(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
+
+    pr_comment_generator.generate()
+
+    pr_comment_generator.gh.add_comment.assert_not_called()
+    pr_comment_generator.gh.update_comment.assert_not_called()
+
+
+def test_none_keeps_existing_comment_untouched(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
+    pr_comment_generator.gh.get_comments.return_value = [{"id": 123, "body": "**JaCoCo**\n\nold body"}]
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=True)
+
+    pr_comment_generator.generate()
+
+    pr_comment_generator.gh.add_comment.assert_not_called()
+    pr_comment_generator.gh.update_comment.assert_not_called()
+    pr_comment_generator.gh.delete_comment.assert_not_called()
+
+
+def test_full_comment_contains_all_tables(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="full")
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "backend": _make_evaluated_coverage("backend", changed_files={"src/Foo.java": 82.0})
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "backend-report": _make_evaluated_coverage(
+            "backend-report",
+            group_name="backend",
+            changed_files={"src/Foo.java": 82.0},
+        )
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "| Metric (instruction) |" in body
+    assert "| Group |" in body
+    assert "| Report |" in body
+    assert "| File Path |" in body
+
+
+def test_changed_filters_group_report_and_file_rows_without_changes(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="changed")
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "changed-group": _make_evaluated_coverage("changed-group", changed_files={"src/Foo.java": 82.0}),
+        "unchanged-group": _make_evaluated_coverage("unchanged-group", changed_files={}),
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "changed-report": _make_evaluated_coverage("changed-report", changed_files={"src/Foo.java": 82.0}),
+        "unchanged-report": _make_evaluated_coverage("unchanged-report", changed_files={}),
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "`changed-group`" in body
+    assert "`unchanged-group`" not in body
+    assert "`changed-report`" in body
+    assert "`unchanged-report`" not in body
+    assert "[Foo.java]" in body
+
+
+def test_failed_filters_only_failing_rows(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="failed")
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "passing-group": _make_evaluated_coverage("passing-group", changed_files={"src/Foo.java": 82.0}),
+        "failing-group": _make_evaluated_coverage(
+            "failing-group",
+            overall_passed=False,
+            changed_passed=False,
+            changed_files={},
+        ),
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "passing-report": _make_evaluated_coverage("passing-report", changed_files={"src/Foo.java": 82.0}),
+        "failing-report": _make_evaluated_coverage(
+            "failing-report",
+            overall_passed=False,
+            changed_passed=False,
+            changed_files={"src/Bar.java": 60.0},
+            changed_threshold=80.0,
+        ),
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "`failing-group`" in body
+    assert "`passing-group`" not in body
+    assert "`failing-report`" in body
+    assert "`passing-report`" not in body
+    assert "[Bar.java]" in body
+    assert "[Foo.java]" not in body
+
+
+def test_failed_or_changed_filters_union_of_rows(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="failed-or-changed")
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "changed-group": _make_evaluated_coverage("changed-group", changed_files={"src/Foo.java": 82.0}),
+        "failing-group": _make_evaluated_coverage("failing-group", overall_passed=False, changed_files={}),
+        "hidden-group": _make_evaluated_coverage("hidden-group", changed_files={}),
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "changed-report": _make_evaluated_coverage("changed-report", changed_files={"src/Foo.java": 82.0}),
+        "failing-report": _make_evaluated_coverage(
+            "failing-report",
+            overall_passed=False,
+            changed_passed=False,
+            changed_files={"src/Bar.java": 60.0},
+            changed_threshold=80.0,
+        ),
+        "hidden-report": _make_evaluated_coverage("hidden-report", changed_files={}),
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "`changed-group`" in body
+    assert "`failing-group`" in body
+    assert "`hidden-group`" not in body
+    assert "`changed-report`" in body
+    assert "`failing-report`" in body
+    assert "`hidden-report`" not in body
+    assert "[Foo.java]" in body
+    assert "[Bar.java]" in body
+
+
+@pytest.mark.parametrize("comment_level", ["changed", "failed", "failed-or-changed"])
+def test_filtered_comment_levels_handle_empty_result_gracefully(pr_comment_generator, mocker, comment_level):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level=comment_level)
+    pr_comment_generator.evaluator.evaluated_groups_coverage = {
+        "hidden-group": _make_evaluated_coverage("hidden-group", changed_files={})
+    }
+    pr_comment_generator.evaluator.evaluated_reports_coverage = {
+        "hidden-report": _make_evaluated_coverage("hidden-report", changed_files={})
+    }
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "| Metric (instruction) |" in body
+    assert "No rows match the selected comment level." in body
+    assert "`hidden-group`" not in body
+    assert "`hidden-report`" not in body

--- a/tests/unit/test_action_inputs.py
+++ b/tests/unit/test_action_inputs.py
@@ -127,6 +127,26 @@ def test_validate_inputs_accepts_all_comment_levels(comment_level, mocker):
         stop_mocks(patchers)
 
 
+@pytest.mark.parametrize("comment_level", ["failing", "change and failing", "detailed"])
+def test_validate_inputs_rejects_noncanonical_comment_level_aliases(comment_level, mocker):
+    case = success_case.copy()
+    case["get_comment_level"] = comment_level
+    patchers = apply_mocks(case, mocker)
+    try:
+        mock_error = mocker.patch("jacoco_report.action_inputs.logger.error")
+        mock_exit = mocker.patch("sys.exit")
+
+        ActionInputs.validate_inputs()
+
+        mock_error.assert_called_with(
+            "'comment-level' must be a string from these options: "
+            "'none', 'minimal', 'full', 'changed', 'failed', 'failed-or-changed'."
+        )
+        mock_exit.assert_called_once_with(1)
+    finally:
+        stop_mocks(patchers)
+
+
 @pytest.mark.parametrize("method, value, expected_error", failure_cases)
 def test_validate_inputs_failure(method, value, expected_error, mocker):
     case = success_case.copy()

--- a/tests/unit/test_action_inputs.py
+++ b/tests/unit/test_action_inputs.py
@@ -60,8 +60,18 @@ failure_cases = [
     ("get_report_thresholds_default", True, "'report-thresholds-default' must be a string or not defined."),
     ("get_metric", "", "'metric' must be a string from these options: 'instruction', 'line', 'branch', 'complexity', 'method', 'class'."),
     ("get_metric", 1, "'metric' must be a string from these options: 'instruction', 'line', 'branch', 'complexity', 'method', 'class'."),
-    ("get_comment_level", "", "'comment-level' must be a string from these options: 'minimal', 'full'."),
-    ("get_comment_level", 1, "'comment-level' must be a string from these options: 'minimal', 'full'."),
+    (
+        "get_comment_level",
+        "",
+        "'comment-level' must be a string from these options: "
+        "'none', 'minimal', 'full', 'changed', 'failed', 'failed-or-changed'.",
+    ),
+    (
+        "get_comment_level",
+        1,
+        "'comment-level' must be a string from these options: "
+        "'none', 'minimal', 'full', 'changed', 'failed', 'failed-or-changed'.",
+    ),
     ("get_report_groups", "not_a_list", "'report-groups' must be a YAML list."),
     ("get_report_groups", "- name: ''\n  paths: ['**']", "'report-groups' entry #1 must have a non-empty 'name'."),
     ("get_report_groups", "- name: group1\n  paths: []", "'report-groups' entry #1 must have a non-empty 'paths' list of non-empty strings."),
@@ -97,6 +107,22 @@ def test_validate_inputs_success(mocker):
     patchers = apply_mocks(success_case, mocker)
     try:
         ActionInputs.validate_inputs()
+    finally:
+        stop_mocks(patchers)
+
+
+@pytest.mark.parametrize(
+    "comment_level",
+    ["none", "minimal", "full", "changed", "failed", "failed-or-changed"],
+)
+def test_validate_inputs_accepts_all_comment_levels(comment_level, mocker):
+    case = success_case.copy()
+    case["get_comment_level"] = comment_level
+    patchers = apply_mocks(case, mocker)
+    try:
+        mock_exit = mocker.patch("sys.exit")
+        ActionInputs.validate_inputs()
+        mock_exit.assert_not_called()
     finally:
         stop_mocks(patchers)
 

--- a/tests/unit/test_skip_unchanged.py
+++ b/tests/unit/test_skip_unchanged.py
@@ -5,7 +5,7 @@ Covers:
 - Filter removes reports with no changed files before evaluation
 - INFO log emitted per filtered report
 - All-reports-filtered → clean exit, no comment, no violations
-- comment-level × skip-unchanged combinations (minimal / full × true / false)
+- comment-level × skip-unchanged combinations across all supported levels
 - fail-on-threshold boolean deprecation warning
 """
 import logging
@@ -165,8 +165,7 @@ def test_skip_unchanged_false_does_not_filter(mocker: MockerFixture, make_report
 
 # --- comment-level × skip-unchanged combinations ---
 #
-# 2 (skip-unchanged: true / false) × 2 (comment-level: minimal / full) = 4 current cases.
-# The remaining 8 cases (none / changed / failed / failed-or-changed) land with Task 30.
+# 2 (skip-unchanged: true / false) × 6 comment levels = 12 cases.
 
 @pytest.fixture
 def evaluator_with_changed(make_report_file_coverage, make_file_coverage):
@@ -190,19 +189,27 @@ def gh_mock(mocker: MockerFixture):
 
 
 @pytest.mark.parametrize("skip_unchanged,comment_level", [
-    (False, CommentLevelEnum.MINIMAL),
-    (False, CommentLevelEnum.FULL),
-    (True,  CommentLevelEnum.MINIMAL),
-    (True,  CommentLevelEnum.FULL),
+    (False, "none"),
+    (False, "minimal"),
+    (False, "full"),
+    (False, "changed"),
+    (False, "failed"),
+    (False, "failed-or-changed"),
+    (True, "none"),
+    (True, "minimal"),
+    (True, "full"),
+    (True, "changed"),
+    (True, "failed"),
+    (True, "failed-or-changed"),
 ])
 def test_comment_level_x_skip_unchanged_comment_posted(
     mocker: MockerFixture,
     gh_mock,
     evaluator_with_changed,
     skip_unchanged: bool,
-    comment_level: CommentLevelEnum,
+    comment_level: str,
 ):
-    """When reports with changed files are present, a comment is always posted regardless of level."""
+    """When changed reports exist, only the NONE level suppresses comment posting."""
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=skip_unchanged)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value=comment_level)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_title", return_value="JaCoCo")
@@ -221,7 +228,41 @@ def test_comment_level_x_skip_unchanged_comment_posted(
     generator = PRCommentGenerator(gh_mock, evaluator_with_changed, bs_evaluator, pr_number=1)
     generator.generate()
 
-    gh_mock.add_comment.assert_called_once()
+    if comment_level == "none":
+        gh_mock.add_comment.assert_not_called()
+    else:
+        gh_mock.add_comment.assert_called_once()
+
+
+@pytest.mark.parametrize("skip_unchanged", [False, True])
+def test_comment_level_none_still_suppresses_comment(
+    mocker: MockerFixture,
+    gh_mock,
+    evaluator_with_changed,
+    skip_unchanged: bool,
+):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_skip_unchanged", return_value=skip_unchanged)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value="none")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_title", return_value="JaCoCo")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_pass_symbol", return_value="✅")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_fail_symbol", return_value="❌")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_overall_threshold", return_value=0.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_global_changed_files_average_threshold", return_value=0.0)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=[])
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_report_groups", return_value=[])
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_update_comment", return_value=True)
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_repository", return_value="owner/repo")
+
+    gh_mock.get_comments.return_value = [{"id": 99, "body": "**JaCoCo**\n\nold content"}]
+
+    bs_evaluator = CoverageEvaluator(report_files_coverage=[], global_min_coverage_overall=0.0,
+                                     global_min_coverage_changed_files=0.0, global_min_coverage_changed_per_file=0.0)
+    generator = PRCommentGenerator(gh_mock, evaluator_with_changed, bs_evaluator, pr_number=1)
+    generator.generate()
+
+    gh_mock.add_comment.assert_not_called()
+    gh_mock.update_comment.assert_not_called()
 
 
 @pytest.mark.parametrize("comment_level", [CommentLevelEnum.MINIMAL, CommentLevelEnum.FULL])


### PR DESCRIPTION
## Overview

Implements task 30 for #102 by expanding `comment-level` from the current binary output model to the full six-level option set.

This PR adds support for:

- `none`
- `minimal`
- `full`
- `changed`
- `failed`
- `failed-or-changed`

Behavior summary:

- `none` suppresses PR comment posting entirely
- `minimal` keeps the global summary table only
- `full` keeps the current full comment output
- `changed` filters group/report/file rows to changed coverage only
- `failed` filters group/report/file rows to failing rows only
- `failed-or-changed` shows the union of changed and failing rows

The change also updates input validation, comment rendering, unit tests, and user-facing documentation.

## RLS Notes

- Added four new `comment-level` values: `none`, `changed`, `failed`, and `failed-or-changed`
- `comment-level: none` now suppresses GitHub PR comment creation/update
- Filtered comment levels keep the global summary table and only filter lower-level rows
- Added coverage for empty-result edge cases and the full `skip-unchanged × comment-level` matrix
- Updated action input docs and README examples to reflect the expanded option set

## Validation

- `python3 -m pytest tests/unit/test_action_inputs.py tests/unit/test_skip_unchanged.py tests/unit/generator/test_pr_comment_generator.py -q`
- `python3 -m pytest --cov=. tests/ --cov-fail-under=80`
- `python3 -m black --check $(git ls-files '*.py')`
- `python3 -m mypy .`

Known repo-level QA status:

- Full `pylint` is still blocked by pre-existing findings outside the scope of this PR

## Related

Closes #102 

Release Notes:

- Expand `comment-level` to six supported values for more precise PR comment control
- Allow users to suppress comments entirely with `comment-level: none`
- Support focused PR comments for changed rows, failing rows, or both
- Document the new comment-level behavior in the action metadata and README
