### PR TITLE
feat: add integration test helpers for action tests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -69,6 +69,8 @@ Two output verbosity levels controlled by `sensitivity`: `detail` / `summary` / 
 | `test_run_failed_to_retrieve_changed_files_marks_threshold_flags_failed` | Ensure operational failure path marks threshold flags as failed | `GitHub.get_pr_changed_files()` returns `None` | Violation is added and all `reached_threshold_*` flags are `False` |
 | `test_run_failed_to_retrieve_changed_files` | Keep existing failure-message assertion while adding threshold assertions | Same as above | Existing violation assertion remains valid and threshold flags are `False` |
 | `test_run_failed_to_retrieve_changed_files` formatting cleanup | Remove trailing whitespace-only lines in the new test block | N/A (format-only change) | No lint/format noise from trailing whitespace |
+| `test_capture_run_clears_preexisting_ci_env_keys` | Ensure stale CI/action env vars do not leak into integration helper execution | Pre-existing `INPUT_*`/`GITHUB_*` vars in `os.environ`, call `capture_run()` with partial overrides | Stale `INPUT_*`/`GITHUB_*` vars are absent during `main.run()` |
+| `test_capture_run_closes_handlers_added_during_run` | Ensure handlers attached during the run are closed during teardown | `main.run()` adds a custom root logger handler | Handler is removed and its `close()` is called in `capture_run()` finally block |
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,8 @@ Two output verbosity levels controlled by `sensitivity`: `detail` / `summary` / 
 | `test_run_failed_to_retrieve_changed_files` formatting cleanup | Remove trailing whitespace-only lines in the new test block | N/A (format-only change) | No lint/format noise from trailing whitespace |
 | `test_capture_run_clears_preexisting_ci_env_keys` | Ensure stale CI/action env vars do not leak into integration helper execution | Pre-existing `INPUT_*`/`GITHUB_*` vars in `os.environ`, call `capture_run()` with partial overrides | Stale `INPUT_*`/`GITHUB_*` vars are absent during `main.run()` |
 | `test_capture_run_closes_handlers_added_during_run` | Ensure handlers attached during the run are closed during teardown | `main.run()` adds a custom root logger handler | Handler is removed and its `close()` is called in `capture_run()` finally block |
+| `test_capture_run_forces_temp_github_output` | Ensure capture_run never writes action outputs to external files | `env_overrides` includes `GITHUB_OUTPUT` external path | `main.run()` receives a temp path and external path remains untouched |
+| `test_make_env_base_includes_default_pr_number` | Ensure base offline env can run without extra PR-number overrides | Call `make_env_base()` with no overrides | Returned env includes `INPUT_PR_NUMBER` default value |
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -71,7 +71,7 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **29** | G | Add `report-thresholds-default` input | ✅ | `feature/113-report-thresholds-default` | #113 |
 | **30** | G | Expand `comment-level` full option set | ✅ | `feature/102-comment-level-full-option-set` | #102 |
 | **31** | G | `fail-on-threshold` boolean deprecation impl | ✅ | `feature/103-fail-on-threshold-deprecation-evaluate-unchanged` | #103 |
-| **32** | H | Integration test helpers module | 🔒 ⬜ | `chore/integration-test-helpers` | new |
+| **32** | H | Integration test helpers module | ✅ | `chore/integration-test-helpers` | new |
 | **33** | H | Golden snapshot tests | 🔒 ⬜ | `chore/golden-snapshot-tests` | new |
 | **34** | H | skip-unchanged × comment-level matrix tests | 🔒 ⬜ | `chore/skip-unchanged-comment-level-matrix-tests` | new |
 | **35** | H | Live integration smoke test | 🔒 ⬜ | `chore/live-integration-smoke-test` | new |
@@ -422,7 +422,7 @@ All Group H tasks depend on at least one Group G task being complete.
 
 ---
 
-#### Task 32 — Integration test helpers module ⬜
+#### Task 32 — Integration test helpers module ✅
 
 **Branch:** `chore/integration-test-helpers`
 **Issue:** new | **Depends on:** Task 19 (directory structure ✅)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,123 @@
+"""
+Integration test helpers for jacoco-report action tests.
+
+Provides capture_run() for running the full action pipeline in-process
+and fixture-assembly helpers for constructing canonical env var inputs.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+TESTS_DIR: Path = Path(__file__).parent.parent
+DATA_DIR: Path = TESTS_DIR / "data"
+TEST_PROJECT_GLOB: str = str(DATA_DIR / "test_project" / "**" / "jacoco.xml")
+BASELINE_PROJECT_GLOB: str = str(TESTS_DIR / "data_baseline" / "test_project" / "**" / "jacoco.xml")
+
+
+@dataclass
+class ActionResult:
+    """Captured outcome of a single capture_run invocation."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def capture_run(env_overrides: dict[str, str]) -> ActionResult:
+    """
+    Run the full action pipeline with env_overrides applied to os.environ.
+
+    Redirects stdout/stderr and resets root-logger handlers so that
+    setup_logging() emits to the captured stream. Catches SystemExit and
+    records its code. Manages a temporary GITHUB_OUTPUT file internally.
+
+    GitHub API calls must be mocked by the caller (via pytest-mock) before
+    invoking this function for offline tests.
+    """
+    import main as jacoco_main  # local import avoids module-level side-effects
+
+    original_env = dict(os.environ)
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+
+    root_logger = logging.getLogger()
+    saved_handlers: list[logging.Handler] = root_logger.handlers[:]
+    saved_level: int = root_logger.level
+    for h in saved_handlers:
+        root_logger.removeHandler(h)
+
+    exit_code = 0
+    tmp_output_path: str | None = None
+
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+            tmp_output_path = tmp.name
+
+        os.environ.update(env_overrides)
+        os.environ.setdefault("GITHUB_OUTPUT", tmp_output_path)
+
+        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+            try:
+                jacoco_main.run()
+            except SystemExit as exc:
+                exit_code = int(exc.code) if exc.code is not None else 0
+    finally:
+        for h in root_logger.handlers[:]:
+            root_logger.removeHandler(h)
+        for h in saved_handlers:
+            root_logger.addHandler(h)
+        root_logger.setLevel(saved_level)
+        os.environ.clear()
+        os.environ.update(original_env)
+        if tmp_output_path and os.path.exists(tmp_output_path):
+            os.unlink(tmp_output_path)
+
+    return ActionResult(
+        exit_code=exit_code,
+        stdout=stdout_buf.getvalue(),
+        stderr=stderr_buf.getvalue(),
+    )
+
+
+def make_env_base(**overrides: str) -> dict[str, str]:
+    """
+    Return a minimal env var dict for offline integration tests.
+
+    Provides sensible defaults for all action inputs. The fake token
+    satisfies the format check in validate_inputs(). GitHub API calls
+    must still be mocked by the caller via pytest-mock.
+
+    Any keyword argument overrides the corresponding default key.
+    """
+    env: dict[str, str] = {
+        # GitHub-injected vars (no INPUT_ prefix)
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REPOSITORY": "owner/repo",
+        # Action inputs
+        "INPUT_TOKEN": "ghs_" + "x" * 36,
+        "INPUT_PATHS": TEST_PROJECT_GLOB,
+        "INPUT_EXCLUDE_PATHS": "",
+        "INPUT_GLOBAL_THRESHOLDS": "0.0*0.0*0.0",
+        "INPUT_REPORT_THRESHOLDS_DEFAULT": "0.0*0.0*0.0",
+        "INPUT_METRIC": "instruction",
+        "INPUT_TITLE": "JaCoCo Coverage Report",
+        "INPUT_COMMENT_LEVEL": "full",
+        "INPUT_SKIP_UNCHANGED": "false",
+        "INPUT_EVALUATE_UNCHANGED": "true",
+        "INPUT_UPDATE_COMMENT": "false",
+        "INPUT_FAIL_ON_THRESHOLD": "overall,changed-files-average,per-changed-file",
+        "INPUT_PASS_SYMBOL": "✅",
+        "INPUT_FAIL_SYMBOL": "❌",
+        "INPUT_DEBUG": "false",
+        "INPUT_BASELINE_PATHS": "",
+        "INPUT_REPORT_GROUPS": "",
+    }
+    env.update(overrides)
+    return env

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -68,7 +68,7 @@ def capture_run(env_overrides: dict[str, str]) -> ActionResult:
             del os.environ[key]
 
         os.environ.update(env_overrides)
-        os.environ.setdefault("GITHUB_OUTPUT", tmp_output_path)
+        os.environ["GITHUB_OUTPUT"] = tmp_output_path
 
         with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
             try:
@@ -118,6 +118,7 @@ def make_env_base(**overrides: str) -> dict[str, str]:
         "INPUT_GLOBAL_THRESHOLDS": "0.0*0.0*0.0",
         "INPUT_REPORT_THRESHOLDS_DEFAULT": "0.0*0.0*0.0",
         "INPUT_METRIC": "instruction",
+        "INPUT_PR_NUMBER": "1",
         "INPUT_TITLE": "JaCoCo Coverage Report",
         "INPUT_COMMENT_LEVEL": "full",
         "INPUT_SKIP_UNCHANGED": "false",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -60,6 +60,13 @@ def capture_run(env_overrides: dict[str, str]) -> ActionResult:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
             tmp_output_path = tmp.name
 
+        for key in [
+            env_key
+            for env_key in os.environ
+            if env_key.startswith("INPUT_") or env_key.startswith("GITHUB_")
+        ]:
+            del os.environ[key]
+
         os.environ.update(env_overrides)
         os.environ.setdefault("GITHUB_OUTPUT", tmp_output_path)
 
@@ -69,8 +76,12 @@ def capture_run(env_overrides: dict[str, str]) -> ActionResult:
             except SystemExit as exc:
                 exit_code = int(exc.code) if exc.code is not None else 0
     finally:
-        for h in root_logger.handlers[:]:
+        captured_handlers: list[logging.Handler] = root_logger.handlers[:]
+        for h in captured_handlers:
             root_logger.removeHandler(h)
+        for h in captured_handlers:
+            if h not in saved_handlers:
+                h.close()
         for h in saved_handlers:
             root_logger.addHandler(h)
         root_logger.setLevel(saved_level)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -38,9 +38,16 @@ def capture_run(env_overrides: dict[str, str]) -> ActionResult:
     """
     Run the full action pipeline with env_overrides applied to os.environ.
 
+    Environment isolation performed before each run:
+    - All pre-existing INPUT_* and GITHUB_* keys are deleted from os.environ
+      so that ambient CI variables cannot bleed into the run.
+    - GITHUB_OUTPUT is always set to an internally managed temp file,
+      regardless of any value supplied in env_overrides, so that action-output
+      side effects are fully contained and cleaned up after the call.
+
     Redirects stdout/stderr and resets root-logger handlers so that
     setup_logging() emits to the captured stream. Catches SystemExit and
-    records its code. Manages a temporary GITHUB_OUTPUT file internally.
+    records its code.
 
     GitHub API calls must be mocked by the caller (via pytest-mock) before
     invoking this function for offline tests.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,6 +3,10 @@ Integration test helpers for jacoco-report action tests.
 
 Provides capture_run() for running the full action pipeline in-process
 and fixture-assembly helpers for constructing canonical env var inputs.
+
+Fixture roots used by this module:
+- TEST_PROJECT_GLOB reads main fixtures from tests/data/test_project/**/jacoco.xml
+- BASELINE_PROJECT_GLOB reads baseline fixtures from tests/data_baseline/test_project/**/jacoco.xml
 """
 
 from __future__ import annotations

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -1,0 +1,63 @@
+import logging
+import os
+
+from pytest_mock import MockerFixture
+
+from tests.integration.helpers import capture_run
+
+
+class TrackingHandler(logging.Handler):
+    """Track whether close() was called during teardown."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.was_closed = False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        del record
+
+    def close(self) -> None:
+        self.was_closed = True
+        super().close()
+
+
+def test_capture_run_clears_preexisting_ci_env_keys(mocker: MockerFixture, monkeypatch) -> None:
+    """Ensure stale INPUT_/GITHUB_ env keys do not leak into capture_run execution."""
+    monkeypatch.setenv("INPUT_STALE", "stale-input")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "stale-event")
+
+    observed_env: dict[str, str | None] = {}
+
+    def fake_run() -> None:
+        observed_env["INPUT_STALE"] = os.getenv("INPUT_STALE")
+        observed_env["GITHUB_EVENT_NAME"] = os.getenv("GITHUB_EVENT_NAME")
+
+    mocker.patch("main.run", side_effect=fake_run)
+
+    capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml"})
+
+    assert observed_env["INPUT_STALE"] is None
+    assert observed_env["GITHUB_EVENT_NAME"] is None
+
+
+def test_capture_run_closes_handlers_added_during_run(mocker: MockerFixture) -> None:
+    """Ensure handlers added during run are removed and closed in teardown."""
+    root_logger = logging.getLogger()
+
+    saved_handler = logging.NullHandler()
+    root_logger.addHandler(saved_handler)
+
+    runtime_handler = TrackingHandler()
+
+    def fake_run() -> None:
+        root_logger.addHandler(runtime_handler)
+
+    mocker.patch("main.run", side_effect=fake_run)
+
+    try:
+        capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml"})
+    finally:
+        if saved_handler in root_logger.handlers:
+            root_logger.removeHandler(saved_handler)
+
+    assert runtime_handler.was_closed is True

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -3,7 +3,7 @@ import os
 
 from pytest_mock import MockerFixture
 
-from tests.integration.helpers import capture_run, make_env_base
+from tests.integration.helpers import TEST_PROJECT_GLOB, capture_run, make_env_base
 
 
 class TrackingHandler(logging.Handler):
@@ -34,7 +34,7 @@ def test_capture_run_clears_preexisting_ci_env_keys(mocker: MockerFixture, monke
 
     mocker.patch("main.run", side_effect=fake_run)
 
-    capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml"})
+    capture_run({"INPUT_PATHS": TEST_PROJECT_GLOB})
 
     assert observed_env["INPUT_STALE"] is None
     assert observed_env["GITHUB_EVENT_NAME"] is None
@@ -55,7 +55,7 @@ def test_capture_run_closes_handlers_added_during_run(mocker: MockerFixture) -> 
     mocker.patch("main.run", side_effect=fake_run)
 
     try:
-        capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml"})
+        capture_run({"INPUT_PATHS": TEST_PROJECT_GLOB})
     finally:
         if saved_handler in root_logger.handlers:
             root_logger.removeHandler(saved_handler)
@@ -78,7 +78,7 @@ def test_capture_run_forces_temp_github_output(mocker: MockerFixture, tmp_path) 
 
     mocker.patch("main.run", side_effect=fake_run)
 
-    capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml", "GITHUB_OUTPUT": str(external_output)})
+    capture_run({**make_env_base(), "GITHUB_OUTPUT": str(external_output)})
 
     assert observed_output_path["value"] is not None
     assert observed_output_path["value"] != str(external_output)

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -3,7 +3,7 @@ import os
 
 from pytest_mock import MockerFixture
 
-from tests.integration.helpers import capture_run
+from tests.integration.helpers import capture_run, make_env_base
 
 
 class TrackingHandler(logging.Handler):
@@ -61,3 +61,32 @@ def test_capture_run_closes_handlers_added_during_run(mocker: MockerFixture) -> 
             root_logger.removeHandler(saved_handler)
 
     assert runtime_handler.was_closed is True
+
+
+def test_capture_run_forces_temp_github_output(mocker: MockerFixture, tmp_path) -> None:
+    """Ensure capture_run ignores external GITHUB_OUTPUT overrides."""
+    external_output = tmp_path / "external-output.txt"
+
+    observed_output_path: dict[str, str | None] = {}
+
+    def fake_run() -> None:
+        output_path = os.getenv("GITHUB_OUTPUT")
+        observed_output_path["value"] = output_path
+        if output_path is not None:
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write("written-by-run\n")
+
+    mocker.patch("main.run", side_effect=fake_run)
+
+    capture_run({"INPUT_PATHS": "tests/data/test_project/**/jacoco.xml", "GITHUB_OUTPUT": str(external_output)})
+
+    assert observed_output_path["value"] is not None
+    assert observed_output_path["value"] != str(external_output)
+    assert external_output.exists() is False
+
+
+def test_make_env_base_includes_default_pr_number() -> None:
+    """Ensure make_env_base provides PR number fallback for offline runs."""
+    env = make_env_base()
+
+    assert env["INPUT_PR_NUMBER"] == "1"


### PR DESCRIPTION
## Overview

Adds `tests/integration/helpers.py` — the shared infrastructure module that offline integration tests (tasks 33, 34) and live smoke tests (task 35) will build on.

The module exposes three things:

- **`ActionResult`** — a dataclass capturing `exit_code`, `stdout`, and `stderr` from a single action run.
- **`capture_run(env_overrides)`** — runs the full `main.run()` pipeline in-process with the supplied env vars. Resets root-logger handlers before each invocation so `setup_logging()` always emits to the captured stream. Catches `SystemExit` for the real exit code. Manages a temporary `GITHUB_OUTPUT` file internally so action-output side-effects don't leak between tests. GitHub API calls must be mocked by the caller via `pytest-mock`.
- **`make_env_base(**overrides)`** — returns a complete `dict[str, str]` of env vars with sensible offline defaults (fake valid-format token, absolute paths to test data fixtures, all boolean inputs pre-set). Any key can be overridden via kwargs.

Two path constants (`TEST_PROJECT_GLOB`, `BASELINE_PROJECT_GLOB`) point to the existing XML fixtures under `tests/data/`.

Release Notes:

- No user-facing changes; test infrastructure only.
