### PR TITLE
feat: add golden snapshot tests for PR comment pipeline and coverage reports

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -72,7 +72,7 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **30** | G | Expand `comment-level` full option set | ✅ | `feature/102-comment-level-full-option-set` | #102 |
 | **31** | G | `fail-on-threshold` boolean deprecation impl | ✅ | `feature/103-fail-on-threshold-deprecation-evaluate-unchanged` | #103 |
 | **32** | H | Integration test helpers module | ✅ | `chore/integration-test-helpers` | new |
-| **33** | H | Golden snapshot tests | 🔒 ⬜ | `chore/golden-snapshot-tests` | new |
+| **33** | H | Golden snapshot tests | ✅ | `chore/golden-snapshot-tests` | new |
 | **34** | H | skip-unchanged × comment-level matrix tests | 🔒 ⬜ | `chore/skip-unchanged-comment-level-matrix-tests` | new |
 | **35** | H | Live integration smoke test | 🔒 ⬜ | `chore/live-integration-smoke-test` | new |
 | **36** | I | Enhanced logging (thresholds + reached values) | 🔒 ⬜ | `feature/101-enhance-threshold-logging` | #101 |

--- a/tests/integration/fixtures/snapshot_no_groups.md
+++ b/tests/integration/fixtures/snapshot_no_groups.md
@@ -1,0 +1,23 @@
+**JaCoCo Coverage Report**
+
+| Metric (instruction) | Coverage | Threshold | Status |
+|----------------------|----------|-----------|--------|
+| **Overall**       | 92.0% | 0.0% | ✅ |
+| **Changed Files** | 90.25% | 0.0% | ✅ |
+
+| Report | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|--------|----------|-----------|--------|
+| `Module Large Report` | 91.33% / 90.25% | 0.0% / 0.0% | ✅/✅ |
+| `Module Small Report` | 97.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `notification: API Module Report` | 95.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `notification: Client HTTP Module Report` | 90.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `notification: Plugins Module Report` | 92.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info:  Controller Module Report` | 93.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: API Module Report` | 95.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: Client HTTP Module Report` | 90.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: Implementation Module Report` | 88.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+
+| File Path | Coverage | Threshold | Status |
+|-----------|----------|-----------|--------|
+| [BigClass.java](https://github.com/owner/repo/pull/1/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 0.0% | ✅ |
+| [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |

--- a/tests/integration/fixtures/snapshot_skip_unchanged.md
+++ b/tests/integration/fixtures/snapshot_skip_unchanged.md
@@ -1,0 +1,14 @@
+**JaCoCo Coverage Report**
+
+| Metric (instruction) | Coverage | Threshold | Status |
+|----------------------|----------|-----------|--------|
+| **Overall**       | 92.0% | 0.0% | ✅ |
+| **Changed Files** | 90.83% | 0.0% | ✅ |
+
+| Report | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|--------|----------|-----------|--------|
+| `Module Large Report` | 91.33% / 90.83% | 0.0% / 0.0% | ✅/✅ |
+
+| File Path | Coverage | Threshold | Status |
+|-----------|----------|-----------|--------|
+| [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |

--- a/tests/integration/fixtures/snapshot_with_groups.md
+++ b/tests/integration/fixtures/snapshot_with_groups.md
@@ -1,0 +1,26 @@
+**JaCoCo Coverage Report**
+
+| Metric (instruction) | Coverage | Threshold | Status |
+|----------------------|----------|-----------|--------|
+| **Overall**       | 91.86% | 0.0% | ✅ |
+| **Changed Files** | 94.0% | 0.0% | ✅ |
+
+| Group | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|-------|----------|-----------|--------|
+| `notification` | 92.33% / 95.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info` | 91.5% / 93.0% | 0.0% / 0.0% | ✅/✅ |
+
+| Report | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|--------|----------|-----------|--------|
+| `notification: API Module Report` | 95.0% / 95.0% | 0.0% / 0.0% | ✅/✅ |
+| `notification: Client HTTP Module Report` | 90.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `notification: Plugins Module Report` | 92.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info:  Controller Module Report` | 93.0% / 93.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: API Module Report` | 95.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: Client HTTP Module Report` | 90.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+| `user-info: Implementation Module Report` | 88.0% / 0.0% | 0.0% / 0.0% | ✅/✅ |
+
+| File Path | Coverage | Threshold | Status |
+|-----------|----------|-----------|--------|
+| [ApiClass.java](https://github.com/owner/repo/pull/1/files#diff-04de1cb2cf0087b2067d518ca69e0fa09d19ac3f70c216d9e6e95f539c22e217) | 95.0% | 0.0% | ✅ |
+| [ControllerClass.java](https://github.com/owner/repo/pull/1/files#diff-f31b78555f698136fc5a92f723c22aec2b1390402b08e26b0f355d028552546d) | 93.0% | 0.0% | ✅ |

--- a/tests/integration/test_golden_snapshots.py
+++ b/tests/integration/test_golden_snapshots.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import pytest
 from pytest_mock import MockerFixture
 
 from tests.integration.helpers import (
@@ -101,6 +100,7 @@ def test_snapshot_no_groups(mocker: MockerFixture) -> None:
     captured = _mock_github(mocker, _CHANGED_FILES_NO_GROUPS)
 
     env = make_env_base(
+        INPUT_PATHS=TEST_PROJECT_GLOB,
         INPUT_COMMENT_LEVEL="full",
         INPUT_SKIP_UNCHANGED="false",
     )
@@ -155,6 +155,7 @@ def test_snapshot_skip_unchanged(mocker: MockerFixture) -> None:
     captured = _mock_github(mocker, _CHANGED_FILES_SKIP_UNCHANGED)
 
     env = make_env_base(
+        INPUT_PATHS=TEST_PROJECT_GLOB,
         INPUT_COMMENT_LEVEL="full",
         INPUT_SKIP_UNCHANGED="true",
         INPUT_EVALUATE_UNCHANGED="true",

--- a/tests/integration/test_golden_snapshots.py
+++ b/tests/integration/test_golden_snapshots.py
@@ -1,0 +1,173 @@
+"""
+Golden snapshot tests for the full PR comment pipeline.
+
+Each test runs the complete action end-to-end with mocked GitHub API calls and
+compares the generated PR comment body to a stored snapshot file.
+
+To regenerate all snapshot files (e.g. after intentional output changes):
+    WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tests.integration.helpers import (
+    DATA_DIR,
+    TEST_PROJECT_GLOB,
+    capture_run,
+    make_env_base,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+_NOTIFICATION_GLOB = str(DATA_DIR / "test_project" / "context" / "notification" / "**" / "jacoco.xml")
+_USER_INFO_GLOB = str(DATA_DIR / "test_project" / "context" / "user-info" / "**" / "jacoco.xml")
+
+# Changed files for scenario 1: only module_large reports have changed files
+_CHANGED_FILES_NO_GROUPS = [
+    "com/example/module_large/MidClass.java",
+    "com/example/module_large/BigClass.java",
+]
+
+# Changed files for scenario 2: one file per group
+_CHANGED_FILES_WITH_GROUPS = [
+    "com/example/notification/api/ApiClass.java",
+    "com/example/user-info/controller/ControllerClass.java",
+]
+
+# Changed files for scenario 3: only module_large; all other reports are filtered by skip-unchanged
+_CHANGED_FILES_SKIP_UNCHANGED = [
+    "com/example/module_large/MidClass.java",
+]
+
+_REPORT_GROUPS_YAML = f"""\
+- name: notification
+  paths:
+    - {_NOTIFICATION_GLOB}
+- name: user-info
+  paths:
+    - {_USER_INFO_GLOB}
+"""
+
+
+def _assert_or_write_snapshot(scenario: str, actual: str) -> None:
+    """Assert actual matches the stored snapshot, or write it when WRITE_SNAPSHOTS=1."""
+    fixture_path = FIXTURES_DIR / f"snapshot_{scenario}.md"
+    if os.environ.get("WRITE_SNAPSHOTS") == "1":
+        FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+        fixture_path.write_text(actual, encoding="utf-8")
+        return
+    assert fixture_path.exists(), (
+        f"Snapshot '{fixture_path.name}' not found. "
+        "Run with WRITE_SNAPSHOTS=1 to generate: "
+        "WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py"
+    )
+    expected = fixture_path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"PR comment output changed for scenario '{scenario}'. "
+        "If this change is intentional, regenerate with: "
+        "WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py"
+    )
+
+
+def _mock_github(mocker: MockerFixture, changed_files: list[str]) -> list[str]:
+    """Patch all GitHub API calls for offline runs. Returns a list that accumulates posted comment bodies."""
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_pr_changed_files",
+        return_value=changed_files,
+    )
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_comments",
+        return_value=[],
+    )
+    captured: list[str] = []
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.add_comment",
+        side_effect=lambda pr_number, body: captured.append(body) or True,
+    )
+    return captured
+
+
+def test_snapshot_no_groups(mocker: MockerFixture) -> None:
+    """Full comment: all reports loaded from TEST_PROJECT_GLOB, no groups configured.
+
+    Two files from module_large appear as changed; all other reports have no changed files.
+    """
+    captured = _mock_github(mocker, _CHANGED_FILES_NO_GROUPS)
+
+    env = make_env_base(
+        INPUT_COMMENT_LEVEL="full",
+        INPUT_SKIP_UNCHANGED="false",
+    )
+    result = capture_run(env)
+
+    assert result.exit_code == 0, (
+        f"Action exited with code {result.exit_code}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert len(captured) == 1, (
+        f"Expected exactly one comment posted, got {len(captured)}.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+    _assert_or_write_snapshot("no_groups", captured[0])
+
+
+def test_snapshot_with_groups(mocker: MockerFixture) -> None:
+    """Full comment: two report groups (notification, user-info), one changed file per group.
+
+    The groups table appears between the global summary and the reports table.
+    """
+    captured = _mock_github(mocker, _CHANGED_FILES_WITH_GROUPS)
+
+    env = make_env_base(
+        INPUT_PATHS="",
+        INPUT_REPORT_GROUPS=_REPORT_GROUPS_YAML,
+        INPUT_COMMENT_LEVEL="full",
+        INPUT_SKIP_UNCHANGED="false",
+    )
+    result = capture_run(env)
+
+    assert result.exit_code == 0, (
+        f"Action exited with code {result.exit_code}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert len(captured) == 1, (
+        f"Expected exactly one comment posted, got {len(captured)}.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+    _assert_or_write_snapshot("with_groups", captured[0])
+
+
+def test_snapshot_skip_unchanged(mocker: MockerFixture) -> None:
+    """Full comment with skip-unchanged active.
+
+    Only module_large has a changed file (MidClass.java).  All other eight reports
+    are scan-stage filtered; evaluate-unchanged keeps their overall coverage in the
+    global summary but hides them from the reports table rows.
+    """
+    captured = _mock_github(mocker, _CHANGED_FILES_SKIP_UNCHANGED)
+
+    env = make_env_base(
+        INPUT_COMMENT_LEVEL="full",
+        INPUT_SKIP_UNCHANGED="true",
+        INPUT_EVALUATE_UNCHANGED="true",
+    )
+    result = capture_run(env)
+
+    assert result.exit_code == 0, (
+        f"Action exited with code {result.exit_code}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert len(captured) == 1, (
+        f"Expected exactly one comment posted, got {len(captured)}.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+    _assert_or_write_snapshot("skip_unchanged", captured[0])


### PR DESCRIPTION
## Summary

- Add `tests/integration/test_golden_snapshots.py` with three end-to-end offline integration tests that capture the full PR comment pipeline: **no-groups**, **with-groups** (groups table active), and **skip-unchanged** (scan-stage filter active)
- Add `tests/integration/fixtures/` containing the three canonical snapshot files (`snapshot_no_groups.md`, `snapshot_with_groups.md`, `snapshot_skip_unchanged.md`) generated from the current output
- Each test mocks all GitHub API calls (`get_pr_changed_files`, `get_comments`, `add_comment`) so no token is needed; tests run under the existing offline integration CI job

## How snapshot regeneration works

When the PR comment output changes intentionally (e.g. after a generator tweak), snapshots are updated with:

```shell
WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py -v

Release Notes:

- pytest tests/integration/test_golden_snapshots.py — all 3 pass
- WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py — snapshots written, then re-run confirms match
- pytest tests/integration/ --ignore=tests/integration/live — full offline integration suite (7 tests) passes