### PR TITLE
test: implement integration tests for skip-unchanged × comment-level matrix

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: --root-dir "${{ github.workspace }}" --verbose --no-progress --timeout 30 './**/*.md'
+          args: --root-dir "${{ github.workspace }}" --verbose --no-progress --timeout 30 --exclude-path '^tests/integration/fixtures/.*\.md$' --exclude '^https://github.com/owner/repo/pull/1/files#diff-' './**/*.md'
           format: markdown
           output: ./lychee-results.md
           token: ${{ secrets.TOKEN }}

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: --root-dir "${{ github.workspace }}" --verbose --no-progress --timeout 30 --exclude-path '^tests/integration/fixtures/.*\.md$' --exclude '^https://github.com/owner/repo/pull/1/files#diff-' './**/*.md'
+          args: --root-dir "${{ github.workspace }}" --verbose --no-progress --timeout 30 './**/*.md'
           format: markdown
           output: ./lychee-results.md
           token: ${{ secrets.TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jacoco Report GitHub Action
 
 ![GitHub tag](https://img.shields.io/github/v/tag/MoranaApps/jacoco-report?label=latest&style=flat-square&color=blue)
+[![CodeRabbit Pull Request Reviews](https://coderabbit.ai/badges/github/MoranaApps/jacoco-report)](https://coderabbit.ai/github/MoranaApps/jacoco-report)
 
 - [Usage](#usage)
   - [Action Inputs](#action-inputs)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Jacoco Report GitHub Action
 
 ![GitHub tag](https://img.shields.io/github/v/tag/MoranaApps/jacoco-report?label=latest&style=flat-square&color=blue)
-[![CodeRabbit Pull Request Reviews](https://coderabbit.ai/badges/github/MoranaApps/jacoco-report)](https://coderabbit.ai/github/MoranaApps/jacoco-report)
 
 - [Usage](#usage)
   - [Action Inputs](#action-inputs)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1201,7 +1201,7 @@ Three items that form the integration test layer:
    Gate regeneration with `WRITE_SNAPSHOTS=1` env var.
    Run as part of offline integration job (no GitHub token needed).
 
-3. **Combination coverage** (`tests/integration/test_skip_unchanged_x_comment_level.py`):
+3. **Combination coverage** (`tests/integration/test_matrix_skip_unchanged_comment_level.py`):
    All 2 × 6 = 12 `skip-unchanged` × `comment-level` combinations, verifying filter-before-
    evaluation semantics from task 27.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -73,6 +73,12 @@ Two output verbosity levels controlled by `sensitivity`: `detail` / `summary` / 
 | `test_capture_run_closes_handlers_added_during_run` | Ensure handlers attached during the run are closed during teardown | `main.run()` adds a custom root logger handler | Handler is removed and its `close()` is called in `capture_run()` finally block |
 | `test_capture_run_forces_temp_github_output` | Ensure capture_run never writes action outputs to external files | `env_overrides` includes `GITHUB_OUTPUT` external path | `main.run()` receives a temp path and external path remains untouched |
 | `test_make_env_base_includes_default_pr_number` | Ensure base offline env can run without extra PR-number overrides | Call `make_env_base()` with no overrides | Returned env includes `INPUT_PR_NUMBER` default value |
+| `test_snapshot_no_groups` | Freeze canonical full-comment output without report groups | `INPUT_PATHS=TEST_PROJECT_GLOB`, `comment-level=full`, `skip-unchanged=false`, changed files in module_large | Exactly one comment is posted and matches `fixtures/snapshot_no_groups.md` |
+| `test_snapshot_with_groups` | Freeze canonical full-comment output when report groups are configured | `INPUT_REPORT_GROUPS` with notification+user-info, `comment-level=full`, `skip-unchanged=false` | Exactly one comment is posted and matches `fixtures/snapshot_with_groups.md` |
+| `test_snapshot_skip_unchanged` | Freeze canonical full-comment output when scan-stage filtering is active | `INPUT_PATHS=TEST_PROJECT_GLOB`, `comment-level=full`, `skip-unchanged=true`, `evaluate-unchanged=true` | Exactly one comment is posted and matches `fixtures/snapshot_skip_unchanged.md` |
+| `test_skip_unchanged_false_all_comment_levels` | Cover all 6 comment levels with skip filter disabled | `skip-unchanged=false`, `comment-level` in `none/minimal/full/changed/failed/failed-or-changed` | Run succeeds for each level; `none` suppresses comment; other levels post one comment with level-specific assertions |
+| `test_skip_unchanged_true_all_comment_levels` | Cover all 6 comment levels with scan-stage skip filter enabled | `skip-unchanged=true`, `evaluate-unchanged=false`, `comment-level` in 6-level matrix | Run succeeds for each level; logs filtering; unchanged report rows excluded in `full`; level-specific assertions hold |
+| `test_filter_before_evaluation_changes_global_coverage` | Prove skip-unchanged filtering occurs before evaluator aggregation | Compare `minimal` comment for `skip-unchanged=false` vs `skip-unchanged=true,evaluate-unchanged=false` | Comment bodies differ because evaluator input set changes after scan-stage filtering |
 
 ---
 
@@ -1200,9 +1206,9 @@ Three items that form the integration test layer:
    evaluation semantics from task 27.
 
 ## Acceptance criteria
-- [ ] `helpers.py` exists with typed `capture_run`
-- [ ] At least 3 golden snapshot fixtures cover: no-groups, with-groups, skip-unchanged
-- [ ] All 12 skip-unchanged × comment-level matrix cases covered and green
+- [x] `helpers.py` exists with typed `capture_run`
+- [x] At least 3 golden snapshot fixtures cover: no-groups, with-groups, skip-unchanged
+- [x] All 12 skip-unchanged × comment-level matrix cases covered and green
 ```
 
 ---

--- a/TASKS.md
+++ b/TASKS.md
@@ -73,7 +73,7 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **31** | G | `fail-on-threshold` boolean deprecation impl | ✅ | `feature/103-fail-on-threshold-deprecation-evaluate-unchanged` | #103 |
 | **32** | H | Integration test helpers module | ✅ | `chore/integration-test-helpers` | new |
 | **33** | H | Golden snapshot tests | ✅ | `chore/golden-snapshot-tests` | new |
-| **34** | H | skip-unchanged × comment-level matrix tests | 🔒 ⬜ | `chore/skip-unchanged-comment-level-matrix-tests` | new |
+| **34** | H | skip-unchanged × comment-level matrix tests | ✅ | `chore/skip-unchanged-comment-level-matrix-tests` | new |
 | **35** | H | Live integration smoke test | 🔒 ⬜ | `chore/live-integration-smoke-test` | new |
 | **36** | I | Enhanced logging (thresholds + reached values) | 🔒 ⬜ | `feature/101-enhance-threshold-logging` | #101 |
 | **37** | I | PR comment metadata | 🔒 ⬜ | `feature/94-pr-comment-metadata` | #94 |
@@ -447,7 +447,7 @@ All Group H tasks depend on at least one Group G task being complete.
 
 ---
 
-#### Task 34 — skip-unchanged × comment-level matrix tests ⬜
+#### Task 34 — skip-unchanged × comment-level matrix tests ✅
 
 **Branch:** `chore/skip-unchanged-comment-level-matrix-tests`
 **Issue:** new | **Depends on:** Tasks 20, 27, 30

--- a/TASKS.md
+++ b/TASKS.md
@@ -434,7 +434,7 @@ All Group H tasks depend on at least one Group G task being complete.
 
 ---
 
-#### Task 33 — Golden snapshot tests ⬜
+#### Task 33 — Golden snapshot tests ✅
 
 **Branch:** `chore/golden-snapshot-tests`
 **Issue:** new | **Depends on:** Tasks 20, 28, 30, 32

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -239,14 +239,12 @@ class PRCommentGenerator:
     ) -> str:
         """Render the global summary table without baseline deltas."""
         return (
-            dedent(
-                """
+            dedent("""
             | Metric ({}) | Coverage | Threshold | Status |
             |----------------------|----------|-----------|--------|
             | **Overall**       | {}% | {}% | {} |
             | **Changed Files** | {}% | {}% | {} |
-        """
-            )
+        """)
             .strip()
             .format(
                 metric,
@@ -278,14 +276,12 @@ class PRCommentGenerator:
         diff_ch = total_changed_files_reached - bs_total_changed_files_reached
 
         return (
-            dedent(
-                """
+            dedent("""
             | Metric ({}) | Coverage | Threshold | Δ Coverage | Status |
             |-------------------|-----|-----|-----|----|
             | **Overall**       | {}% | {}% | {}{}% | {} |
             | **Changed Files** | {}% | {}% | {}{}% | {} |
-        """
-            )
+        """)
             .strip()
             .format(
                 metric,

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -239,14 +239,12 @@ class PRCommentGenerator:
     ) -> str:
         """Render the global summary table without baseline deltas."""
         return (
-            dedent(
-                """
+            dedent("""
             | Metric ({}) | Coverage | Threshold | Status |
             |----------------------|----------|-----------|--------|
             | **Overall**       | {}% | {}% | {} |
             | **Changed Files** | {}% | {}% | {} |
-        """
-            )
+        """)
             .strip()
             .format(
                 metric,
@@ -278,14 +276,12 @@ class PRCommentGenerator:
         diff_ch = total_changed_files_reached - bs_total_changed_files_reached
 
         return (
-            dedent(
-                """
+            dedent("""
             | Metric ({}) | Coverage | Threshold | Δ Coverage | Status |
             |-------------------|-----|-----|-----|----|
             | **Overall**       | {}% | {}% | {}{}% | {} |
             | **Changed Files** | {}% | {}% | {}{}% | {} |
-        """
-            )
+        """)
             .strip()
             .format(
                 metric,
@@ -318,24 +314,20 @@ class PRCommentGenerator:
         has_baseline = self._has_baseline_data()
 
         if not has_baseline:
-            s = dedent(
-                """
+            s = dedent("""
                 | Group | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
                 |-------|----------|-----------|--------|
-            """
-            ).strip()
+            """).strip()
             for group_name, ev in sorted(evaluated_groups_coverage.items()):
                 cov = f"{ev.overall_coverage_reached}% / {ev.avg_changed_files_coverage_reached}%"
                 thres = f"{ev.overall_coverage_threshold}% / {ev.changed_files_threshold}%"
                 status = f"{p if ev.overall_passed else f}/{p if ev.avg_changed_files_passed else f}"
                 s += f"\n| `{group_name}` | {cov} | {thres} | {status} |"
         else:
-            s = dedent(
-                """
+            s = dedent("""
                 | Group | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |
                 |-------|----------|-----------|------------|--------|
-            """
-            ).strip()
+            """).strip()
             for group_name, ev in sorted(evaluated_groups_coverage.items()):
                 diff_o, diff_ch = self.calculate_baseline_group_diffs(ev)
                 diff_o = round(diff_o, 2)
@@ -371,12 +363,10 @@ class PRCommentGenerator:
         if not evaluated_reports_coverage:
             return ""
 
-        s = dedent(
-            """
+        s = dedent("""
             | Report | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
             |--------|----------|-----------|--------|
-        """
-        ).strip()
+        """).strip()
 
         keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
@@ -406,12 +396,10 @@ class PRCommentGenerator:
         if not evaluated_reports_coverage:
             return ""
 
-        s = dedent(
-            """
+        s = dedent("""
             | Report | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |
             |--------|----------|-----------|------------|--------|
-        """
-        ).strip()
+        """).strip()
 
         keys: list[str] = sorted(list(evaluated_reports_coverage.keys()))
         for key in keys:
@@ -486,12 +474,10 @@ class PRCommentGenerator:
         """
         Generate a table with changed files without baseline. The table contains the files from all reports.
         """
-        s = dedent(
-            """
+        s = dedent("""
             | File Path | Coverage | Threshold | Status |
             |-----------|----------|-----------|--------|
-        """
-        ).strip()
+        """).strip()
 
         if evaluated_reports_coverage is None:
             evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage
@@ -571,12 +557,10 @@ class PRCommentGenerator:
         self, p: str, f: str, evaluated_reports_coverage: Optional[dict[str, EvaluatedReportCoverage]] = None
     ) -> str:
         """Generate a changed-files table that includes baseline deltas."""
-        s = dedent(
-            """
+        s = dedent("""
             | File Path | Coverage | Threshold | Δ Coverage | Status |
             |-----------|----------|-----------|------------|--------|
-        """
-        ).strip()
+        """).strip()
 
         if evaluated_reports_coverage is None:
             evaluated_reports_coverage = self.evaluator.evaluated_reports_coverage

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -239,12 +239,14 @@ class PRCommentGenerator:
     ) -> str:
         """Render the global summary table without baseline deltas."""
         return (
-            dedent("""
+            dedent(
+                """
             | Metric ({}) | Coverage | Threshold | Status |
             |----------------------|----------|-----------|--------|
             | **Overall**       | {}% | {}% | {} |
             | **Changed Files** | {}% | {}% | {} |
-        """)
+        """
+            )
             .strip()
             .format(
                 metric,
@@ -276,12 +278,14 @@ class PRCommentGenerator:
         diff_ch = total_changed_files_reached - bs_total_changed_files_reached
 
         return (
-            dedent("""
+            dedent(
+                """
             | Metric ({}) | Coverage | Threshold | Δ Coverage | Status |
             |-------------------|-----|-----|-----|----|
             | **Overall**       | {}% | {}% | {}{}% | {} |
             | **Changed Files** | {}% | {}% | {}{}% | {} |
-        """)
+        """
+            )
             .strip()
             .format(
                 metric,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -149,7 +149,20 @@ def make_env_base(**overrides: str) -> dict[str, str]:
 
 
 def mock_github_offline(mocker: MockerFixture, changed_files: list[str]) -> list[str]:
-    """Patch GitHub API calls for offline integration tests and capture posted comment bodies."""
+    """Patch GitHub API calls for offline integration tests.
+
+    Parameters
+    ----------
+    mocker
+        pytest-mock fixture used to patch GitHub client methods.
+    changed_files
+        Changed file paths returned by the mocked pull-request changed-files API.
+
+    Returns
+    -------
+    list[str]
+        Mutable list that accumulates posted PR comment bodies.
+    """
     mocker.patch(
         "jacoco_report.utils.github.GitHub.get_pr_changed_files",
         return_value=changed_files,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,6 +19,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 
+from pytest_mock import MockerFixture
+
 TESTS_DIR: Path = Path(__file__).parent.parent
 DATA_DIR: Path = TESTS_DIR / "data"
 TEST_PROJECT_GLOB: str = str(DATA_DIR / "test_project" / "**" / "jacoco.xml")
@@ -144,3 +146,21 @@ def make_env_base(**overrides: str) -> dict[str, str]:
     }
     env.update(overrides)
     return env
+
+
+def mock_github_offline(mocker: MockerFixture, changed_files: list[str]) -> list[str]:
+    """Patch GitHub API calls for offline integration tests and capture posted comment bodies."""
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_pr_changed_files",
+        return_value=changed_files,
+    )
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_comments",
+        return_value=[],
+    )
+    captured: list[str] = []
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.add_comment",
+        side_effect=lambda pr_number, body: captured.append(body) or True,
+    )
+    return captured

--- a/tests/integration/test_golden_snapshots.py
+++ b/tests/integration/test_golden_snapshots.py
@@ -20,6 +20,7 @@ from tests.integration.helpers import (
     TEST_PROJECT_GLOB,
     capture_run,
     make_env_base,
+    mock_github_offline,
 )
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -74,30 +75,12 @@ def _assert_or_write_snapshot(scenario: str, actual: str) -> None:
     )
 
 
-def _mock_github(mocker: MockerFixture, changed_files: list[str]) -> list[str]:
-    """Patch all GitHub API calls for offline runs. Returns a list that accumulates posted comment bodies."""
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.get_pr_changed_files",
-        return_value=changed_files,
-    )
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.get_comments",
-        return_value=[],
-    )
-    captured: list[str] = []
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.add_comment",
-        side_effect=lambda pr_number, body: captured.append(body) or True,
-    )
-    return captured
-
-
 def test_snapshot_no_groups(mocker: MockerFixture) -> None:
     """Full comment: all reports loaded from TEST_PROJECT_GLOB, no groups configured.
 
     Two files from module_large appear as changed; all other reports have no changed files.
     """
-    captured = _mock_github(mocker, _CHANGED_FILES_NO_GROUPS)
+    captured = mock_github_offline(mocker, _CHANGED_FILES_NO_GROUPS)
 
     env = make_env_base(
         INPUT_PATHS=TEST_PROJECT_GLOB,
@@ -123,7 +106,7 @@ def test_snapshot_with_groups(mocker: MockerFixture) -> None:
 
     The groups table appears between the global summary and the reports table.
     """
-    captured = _mock_github(mocker, _CHANGED_FILES_WITH_GROUPS)
+    captured = mock_github_offline(mocker, _CHANGED_FILES_WITH_GROUPS)
 
     env = make_env_base(
         INPUT_PATHS="",
@@ -152,7 +135,7 @@ def test_snapshot_skip_unchanged(mocker: MockerFixture) -> None:
     are scan-stage filtered; evaluate-unchanged keeps their overall coverage in the
     global summary but hides them from the reports table rows.
     """
-    captured = _mock_github(mocker, _CHANGED_FILES_SKIP_UNCHANGED)
+    captured = mock_github_offline(mocker, _CHANGED_FILES_SKIP_UNCHANGED)
 
     env = make_env_base(
         INPUT_PATHS=TEST_PROJECT_GLOB,

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -4,10 +4,11 @@
 """
 Integration tests: skip-unchanged × comment-level matrix (Task 34).
 
-Covers all 2 × 6 = 12 combinations of skip-unchanged × comment-level and
-verifies filter-before-evaluation semantics: with skip-unchanged=true,
-unchanged reports are removed at the scan stage — before CoverageEvaluator
-runs — so they never appear in comment tables regardless of comment level.
+Covers all 2 × 6 = 12 combinations of skip-unchanged × comment-level.
+The evaluate-unchanged=false branch is exercised throughout: with
+skip-unchanged=true and evaluate-unchanged=false, unchanged reports are
+removed at the scan stage before CoverageEvaluator runs and are fully
+excluded from both comment rows and global threshold evaluation.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from __future__ import annotations
 import pytest
 from pytest_mock import MockerFixture
 
+from jacoco_report.utils.enums import CommentLevelEnum
 from tests.integration.helpers import (
     TEST_PROJECT_GLOB,
     capture_run,
@@ -30,7 +32,7 @@ _CHANGED_REPORT = "Module Large Report"
 # Report that is filtered when skip-unchanged=true (no changed files).
 _UNCHANGED_REPORT = "Module Small Report"
 
-_COMMENT_LEVELS = ["none", "minimal", "full", "changed", "failed", "failed-or-changed"]
+_COMMENT_LEVELS = [level.value for level in CommentLevelEnum]
 
 
 def _mock_github(mocker: MockerFixture) -> list[str]:
@@ -100,6 +102,10 @@ def test_skip_unchanged_false_all_comment_levels(
             f"[skip=false, level={comment_level!r}] {_CHANGED_REPORT!r} must appear "
             f"(it has changed files)"
         )
+        assert _UNCHANGED_REPORT not in captured[0], (
+            f"[skip=false, level={comment_level!r}] {_UNCHANGED_REPORT!r} must be absent — "
+            f"this level filters to rows with changed files only"
+        )
 
     if comment_level == "failed":
         # At 0% thresholds all reports pass — no failing rows in tables.
@@ -113,7 +119,7 @@ def test_skip_unchanged_false_all_comment_levels(
 def test_skip_unchanged_true_all_comment_levels(
     mocker: MockerFixture, comment_level: str
 ) -> None:
-    """skip-unchanged=true: unchanged reports filtered before evaluation for all comment levels.
+    """skip-unchanged=true + evaluate-unchanged=false: unchanged reports filtered before evaluation.
 
     Verifies:
     - Action completes without error for all 6 levels

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -1,0 +1,216 @@
+"""
+Integration tests: skip-unchanged × comment-level matrix (Task 34).
+
+Covers all 2 × 6 = 12 combinations of skip-unchanged × comment-level and
+verifies filter-before-evaluation semantics: with skip-unchanged=true,
+unchanged reports are removed at the scan stage — before CoverageEvaluator
+runs — so they never appear in comment tables regardless of comment level.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tests.integration.helpers import (
+    TEST_PROJECT_GLOB,
+    capture_run,
+    make_env_base,
+)
+
+# Only module_large files are changed; all other reports have no changed files.
+_CHANGED_FILES = ["com/example/module_large/MidClass.java"]
+
+# Report that always survives the scan-stage filter (has a changed file).
+_CHANGED_REPORT = "Module Large Report"
+
+# Report that is filtered when skip-unchanged=true (no changed files).
+_UNCHANGED_REPORT = "Module Small Report"
+
+_COMMENT_LEVELS = ["none", "minimal", "full", "changed", "failed", "failed-or-changed"]
+
+
+def _mock_github(mocker: MockerFixture) -> list[str]:
+    """Patch all GitHub API calls for offline runs. Returns captured comment bodies."""
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_pr_changed_files",
+        return_value=_CHANGED_FILES,
+    )
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.get_comments",
+        return_value=[],
+    )
+    captured: list[str] = []
+    mocker.patch(
+        "jacoco_report.utils.github.GitHub.add_comment",
+        side_effect=lambda pr_number, body: captured.append(body) or True,
+    )
+    return captured
+
+
+@pytest.mark.parametrize("comment_level", _COMMENT_LEVELS)
+def test_skip_unchanged_false_all_comment_levels(
+    mocker: MockerFixture, comment_level: str
+) -> None:
+    """skip-unchanged=false: all reports reach evaluation for every comment level.
+
+    Verifies:
+    - Action completes without error for all 6 levels
+    - 'none' suppresses the comment; all other levels post exactly one comment
+    - 'full' level includes unchanged report rows (no scan-stage filter active)
+    - 'changed' and 'failed-or-changed' levels include the report with changed files
+    - 'failed' level emits 'No rows match' (all reports pass at 0% thresholds)
+    """
+    captured = _mock_github(mocker)
+
+    result = capture_run(
+        make_env_base(
+            INPUT_PATHS=TEST_PROJECT_GLOB,
+            INPUT_SKIP_UNCHANGED="false",
+            INPUT_COMMENT_LEVEL=comment_level,
+        )
+    )
+
+    assert result.exit_code == 0, (
+        f"[skip=false, level={comment_level!r}] Unexpected exit code {result.exit_code}.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+    if comment_level == "none":
+        assert len(captured) == 0, (
+            f"[skip=false, level=none] comment-level=none must suppress the comment"
+        )
+    else:
+        assert len(captured) == 1, (
+            f"[skip=false, level={comment_level!r}] Expected one comment, got {len(captured)}"
+        )
+
+    if comment_level == "full":
+        assert _UNCHANGED_REPORT in captured[0], (
+            f"[skip=false, level=full] {_UNCHANGED_REPORT!r} must appear "
+            f"(no filter applied — all reports reach evaluation)"
+        )
+        assert _CHANGED_REPORT in captured[0]
+
+    if comment_level in ("changed", "failed-or-changed"):
+        assert _CHANGED_REPORT in captured[0], (
+            f"[skip=false, level={comment_level!r}] {_CHANGED_REPORT!r} must appear "
+            f"(it has changed files)"
+        )
+
+    if comment_level == "failed":
+        # At 0% thresholds all reports pass — no failing rows in tables.
+        assert "No rows match the selected comment level." in captured[0], (
+            f"[skip=false, level=failed] Expected 'No rows match' message "
+            f"(all reports pass at 0% threshold)"
+        )
+
+
+@pytest.mark.parametrize("comment_level", _COMMENT_LEVELS)
+def test_skip_unchanged_true_all_comment_levels(
+    mocker: MockerFixture, comment_level: str
+) -> None:
+    """skip-unchanged=true: unchanged reports filtered before evaluation for all comment levels.
+
+    Verifies:
+    - Action completes without error for all 6 levels
+    - 'none' suppresses the comment; all other levels post exactly one comment
+    - Log output confirms reports are filtered at the scan stage (before evaluation)
+    - 'full' level does NOT include unchanged report rows (filter-before-evaluation)
+    - 'changed' and 'failed-or-changed' include the report with changed files
+    - 'failed' emits 'No rows match' (the surviving report passes at 0% threshold)
+    """
+    captured = _mock_github(mocker)
+
+    result = capture_run(
+        make_env_base(
+            INPUT_PATHS=TEST_PROJECT_GLOB,
+            INPUT_SKIP_UNCHANGED="true",
+            INPUT_EVALUATE_UNCHANGED="false",
+            INPUT_COMMENT_LEVEL=comment_level,
+        )
+    )
+
+    assert result.exit_code == 0, (
+        f"[skip=true, level={comment_level!r}] Unexpected exit code {result.exit_code}.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+    # Scan-stage filter log must appear — confirms filter runs before evaluation.
+    assert "Filtering report" in result.stdout, (
+        f"[skip=true, level={comment_level!r}] Expected scan-stage filter log in stdout; "
+        f"Module Small Report (and others) have no changed files and must be filtered."
+    )
+
+    if comment_level == "none":
+        assert len(captured) == 0, (
+            f"[skip=true, level=none] comment-level=none must suppress the comment"
+        )
+    else:
+        assert len(captured) == 1, (
+            f"[skip=true, level={comment_level!r}] Expected one comment, got {len(captured)}"
+        )
+
+    if comment_level == "full":
+        assert _UNCHANGED_REPORT not in captured[0], (
+            f"[skip=true, level=full] {_UNCHANGED_REPORT!r} must be absent — "
+            f"filter-before-evaluation: removed at scan stage, not inside comment generator"
+        )
+        assert _CHANGED_REPORT in captured[0], (
+            f"[skip=true, level=full] {_CHANGED_REPORT!r} must appear "
+            f"(survived scan-stage filter — has changed files)"
+        )
+
+    if comment_level in ("changed", "failed-or-changed"):
+        assert _CHANGED_REPORT in captured[0], (
+            f"[skip=true, level={comment_level!r}] {_CHANGED_REPORT!r} must appear "
+            f"(has changed files, survived filter)"
+        )
+
+    if comment_level == "failed":
+        # At 0% thresholds the surviving report (module_large) passes — no failing rows.
+        assert "No rows match the selected comment level." in captured[0], (
+            f"[skip=true, level=failed] Expected 'No rows match' message "
+            f"(module_large passes at 0% threshold)"
+        )
+
+
+def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture) -> None:
+    """Global coverage summary differs between skip-unchanged=false and skip-unchanged=true.
+
+    With skip-unchanged=false all reports contribute to the global totals.
+    With skip-unchanged=true + evaluate-unchanged=false only the changed report contributes.
+
+    The minimal-level comment bodies must differ, proving the filter runs before the
+    CoverageEvaluator rather than inside the comment generator.
+    """
+    # Run 1: no filter — all reports in evaluator.
+    captured_all = _mock_github(mocker)
+    r1 = capture_run(
+        make_env_base(
+            INPUT_PATHS=TEST_PROJECT_GLOB,
+            INPUT_SKIP_UNCHANGED="false",
+            INPUT_COMMENT_LEVEL="minimal",
+        )
+    )
+    assert r1.exit_code == 0, f"Run 1 failed: {r1.stdout}"
+    assert len(captured_all) == 1, f"Expected one comment in run 1, got {len(captured_all)}"
+
+    # Run 2: scan-stage filter active — only module_large in evaluator.
+    captured_filtered = _mock_github(mocker)
+    r2 = capture_run(
+        make_env_base(
+            INPUT_PATHS=TEST_PROJECT_GLOB,
+            INPUT_SKIP_UNCHANGED="true",
+            INPUT_EVALUATE_UNCHANGED="false",
+            INPUT_COMMENT_LEVEL="minimal",
+        )
+    )
+    assert r2.exit_code == 0, f"Run 2 failed: {r2.stdout}"
+    assert len(captured_filtered) == 1, f"Expected one comment in run 2, got {len(captured_filtered)}"
+
+    assert captured_all[0] != captured_filtered[0], (
+        "Global coverage summary must differ between skip-unchanged=false (all reports evaluated) "
+        "and skip-unchanged=true (only the changed report evaluated). "
+        "Matching bodies would indicate the filter is not running before the evaluator."
+    )

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -5,10 +5,10 @@
 Integration tests: skip-unchanged × comment-level matrix (Task 34).
 
 Covers all 2 × 6 = 12 combinations of skip-unchanged × comment-level.
-The evaluate-unchanged=false branch is exercised throughout: with
-skip-unchanged=true and evaluate-unchanged=false, unchanged reports are
-removed at the scan stage before CoverageEvaluator runs and are fully
-excluded from both comment rows and global threshold evaluation.
+For skip-unchanged=true cases, the evaluate-unchanged=false branch is exercised:
+unchanged reports are removed at the scan stage before CoverageEvaluator runs
+and are fully excluded from both comment rows and global threshold evaluation.
+For skip-unchanged=false cases, evaluate-unchanged has no effect.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -1,3 +1,6 @@
+# Copyright (c) MoranaApps
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests: skip-unchanged × comment-level matrix (Task 34).
 

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -21,6 +21,7 @@ from tests.integration.helpers import (
     TEST_PROJECT_GLOB,
     capture_run,
     make_env_base,
+    mock_github_offline,
 )
 
 # Only module_large files are changed; all other reports have no changed files.
@@ -33,24 +34,6 @@ _CHANGED_REPORT = "Module Large Report"
 _UNCHANGED_REPORT = "Module Small Report"
 
 _COMMENT_LEVELS = [level.value for level in CommentLevelEnum]
-
-
-def _mock_github(mocker: MockerFixture) -> list[str]:
-    """Patch all GitHub API calls for offline runs. Returns captured comment bodies."""
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.get_pr_changed_files",
-        return_value=_CHANGED_FILES,
-    )
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.get_comments",
-        return_value=[],
-    )
-    captured: list[str] = []
-    mocker.patch(
-        "jacoco_report.utils.github.GitHub.add_comment",
-        side_effect=lambda pr_number, body: captured.append(body) or True,
-    )
-    return captured
 
 
 @pytest.mark.parametrize("comment_level", _COMMENT_LEVELS)
@@ -66,7 +49,7 @@ def test_skip_unchanged_false_all_comment_levels(
     - 'changed' and 'failed-or-changed' levels include the report with changed files
     - 'failed' level emits 'No rows match' (all reports pass at 0% thresholds)
     """
-    captured = _mock_github(mocker)
+    captured = mock_github_offline(mocker, _CHANGED_FILES)
 
     result = capture_run(
         make_env_base(
@@ -129,7 +112,7 @@ def test_skip_unchanged_true_all_comment_levels(
     - 'changed' and 'failed-or-changed' include the report with changed files
     - 'failed' emits 'No rows match' (the surviving report passes at 0% threshold)
     """
-    captured = _mock_github(mocker)
+    captured = mock_github_offline(mocker, _CHANGED_FILES)
 
     result = capture_run(
         make_env_base(
@@ -194,7 +177,7 @@ def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture)
     CoverageEvaluator rather than inside the comment generator.
     """
     # Run 1: no filter — all reports in evaluator.
-    captured_all = _mock_github(mocker)
+    captured_all = mock_github_offline(mocker, _CHANGED_FILES)
     r1 = capture_run(
         make_env_base(
             INPUT_PATHS=TEST_PROJECT_GLOB,
@@ -206,7 +189,7 @@ def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture)
     assert len(captured_all) == 1, f"Expected one comment in run 1, got {len(captured_all)}"
 
     # Run 2: scan-stage filter active — only module_large in evaluator.
-    captured_filtered = _mock_github(mocker)
+    captured_filtered = mock_github_offline(mocker, _CHANGED_FILES)
     r2 = capture_run(
         make_env_base(
             INPUT_PATHS=TEST_PROJECT_GLOB,

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -13,6 +13,8 @@ For skip-unchanged=false cases, evaluate-unchanged has no effect.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -34,6 +36,13 @@ _CHANGED_REPORT = "Module Large Report"
 _UNCHANGED_REPORT = "Module Small Report"
 
 _COMMENT_LEVELS = [level.value for level in CommentLevelEnum]
+
+
+def _extract_overall_coverage(comment_body: str) -> float:
+    """Extract the global Overall coverage percentage from the summary table."""
+    match = re.search(r"\| \*\*Overall\*\*\s+\|\s+([0-9]+(?:\.[0-9]+)?)%\s+\|", comment_body)
+    assert match is not None, f"Could not parse Overall coverage from comment body:\n{comment_body}"
+    return float(match.group(1))
 
 
 @pytest.mark.parametrize("comment_level", _COMMENT_LEVELS)
@@ -128,10 +137,15 @@ def test_skip_unchanged_true_all_comment_levels(
         f"stdout:\n{result.stdout}"
     )
 
-    # Scan-stage filter log must appear — confirms filter runs before evaluation.
-    assert "Filtering report" in result.stdout, (
-        f"[skip=true, level={comment_level!r}] Expected scan-stage filter log in stdout; "
-        f"Module Small Report (and others) have no changed files and must be filtered."
+    expected_filter_log = (
+        f"Filtering report '{_UNCHANGED_REPORT}' from evaluation and comment rows: no changed files."
+    )
+    assert expected_filter_log in result.stdout, (
+        f"[skip=true, level={comment_level!r}] Expected exact scan-stage filter log for "
+        f"{_UNCHANGED_REPORT!r} in stdout.\nstdout:\n{result.stdout}"
+    )
+    assert f"Filtering report '{_CHANGED_REPORT}'" not in result.stdout, (
+        f"[skip=true, level={comment_level!r}] {_CHANGED_REPORT!r} has changed files and must not be filtered."
     )
 
     if comment_level == "none":
@@ -200,6 +214,22 @@ def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture)
     )
     assert r2.exit_code == 0, f"Run 2 failed: {r2.stdout}"
     assert len(captured_filtered) == 1, f"Expected one comment in run 2, got {len(captured_filtered)}"
+
+    expected_filter_log = (
+        f"Filtering report '{_UNCHANGED_REPORT}' from evaluation and comment rows: no changed files."
+    )
+    assert expected_filter_log not in r1.stdout, (
+        "Run 1 uses skip-unchanged=false; no report should be scan-stage filtered."
+    )
+    assert expected_filter_log in r2.stdout, (
+        "Run 2 must log that the unchanged report was filtered before evaluation."
+    )
+
+    overall_all = _extract_overall_coverage(captured_all[0])
+    overall_filtered = _extract_overall_coverage(captured_filtered[0])
+    assert overall_all != overall_filtered, (
+        "Global Overall coverage must change when unchanged reports are excluded from evaluator input."
+    )
 
     assert captured_all[0] != captured_filtered[0], (
         "Global coverage summary must differ between skip-unchanged=false (all reports evaluated) "


### PR DESCRIPTION
## Summary
Add integration coverage for the skip-unchanged × comment-level behavior matrix to ensure comment generation remains correct across supported configuration combinations.

## Changes
- Added a new integration test suite that exercises matrix scenarios for skip-unchanged and comment-level.
- Covered expected behavior for unchanged reports under each comment-level mode.
- Updated project task tracking to reflect this test addition.

## Validation
- Run: `pytest tests/integration/ -k "skip_unchanged or comment_level"`
- Run full gate: `pytest --cov=. tests/ --cov-fail-under=80 && pylint $(git ls-files '*.py') && black --check $(git ls-files '*.py') && mypy .`

Release Notes:
- New Integration tests for skip-unchanged × comment-level behavior matrix.