### PR TITLE
feat: add GitHub metadata to PR comments and enhance logging for cove…

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -80,6 +80,15 @@ Two output verbosity levels controlled by `sensitivity`: `detail` / `summary` / 
 | `test_skip_unchanged_true_all_comment_levels` | Cover all 6 comment levels with scan-stage skip filter enabled | `skip-unchanged=true`, `evaluate-unchanged=false`, `comment-level` in 6-level matrix | Run succeeds for each level; logs filtering; unchanged report rows excluded in `full`; level-specific assertions hold |
 | `test_filter_before_evaluation_changes_global_coverage` | Prove skip-unchanged filtering occurs before evaluator aggregation | Compare `minimal` comment for `skip-unchanged=false` vs `skip-unchanged=true,evaluate-unchanged=false` | Comment bodies differ because evaluator input set changes after scan-stage filtering |
 
+## 9. Confirmed Test Cases (2026-05-13)
+
+| Test name | Intent | Input summary | Expected output |
+|---|---|---|---|
+| `test_metadata_footer_appended_to_comment_body` | Ensure generated comment footer is self-describing when all metadata fields are present | `generate()` with run id, event, action ref, started at, and repository set | Comment body footer includes `Run ...`, `Event: ...`, `Action: ...`, and `Started: ...` |
+| `test_metadata_footer_without_run_id_appended_to_comment_body` | Ensure footer still renders labeled metadata when run id is absent | `generate()` with empty run id, but event, action ref, and started at present | Comment body omits `Run` and still includes labeled `Event`, `Action`, and `Started` fields |
+| `test_metadata_footer_all_empty_returns_no_footer_in_comment_body` | Ensure no footer is appended when all metadata inputs are empty | `generate()` or `_get_comment_content()` with all metadata getters returning empty strings | Generated comment body contains no metadata separator/footer |
+| `test_metadata_footer_run_id_without_repository_appended_to_comment_body` | Ensure run id falls back to inline code when repository is unavailable | `generate()` with run id set, repository empty, and other metadata empty | Comment body footer includes `Run `42`` and no GitHub Actions URL |
+
 ---
 
 ## 2. Current Master State (mid-dev, pre-v3.0.0)

--- a/TASKS.md
+++ b/TASKS.md
@@ -75,8 +75,8 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **33** | H | Golden snapshot tests | ✅ | `chore/golden-snapshot-tests` | new |
 | **34** | H | skip-unchanged × comment-level matrix tests | ✅ | `chore/skip-unchanged-comment-level-matrix-tests` | new |
 | **35** | H | Live integration smoke test | ✅ | `chore/live-integration-smoke-test` | new |
-| **36** | I | Enhanced logging (thresholds + reached values) | 🔒 ⬜ | `feature/101-enhance-threshold-logging` | #101 |
-| **37** | I | PR comment metadata | 🔒 ⬜ | `feature/94-pr-comment-metadata` | #94 |
+| **36** | I | Enhanced logging (thresholds + reached values) | ✅ | `feature/101-enhance-threshold-logging` | #101 |
+| **37** | I | PR comment metadata | ✅ | `feature/94-pr-comment-metadata` | #94 |
 | **38** | J | v2→v3 migration guide | ✅ | `docs/74-v2-v3-migration-guide` | #74 |
 | **39** | J | Create `docs/` directory | 🔒 ⬜ | `docs/extended-docs-directory` | new |
 | **40** | J | Update `DEVELOPER.md` | 🔒 ⬜ | `docs/update-developer-md` | new |
@@ -482,7 +482,7 @@ Both tasks depend on Group G being substantially complete.
 
 Include threshold values and reached values in log output for each evaluation step.
 
-#### Task 37 — PR comment metadata ⬜
+#### Task 37 — PR comment metadata ✅
 
 **Branch:** `feature/94-pr-comment-metadata` | **Issue:** #94
 

--- a/jacoco_report/action_inputs.py
+++ b/jacoco_report/action_inputs.py
@@ -30,6 +30,9 @@ from jacoco_report.utils.constants import (
     METRIC,
     PR_NUMBER,
     BASELINE_PATHS,
+    GITHUB_RUN_ID,
+    GITHUB_RUN_STARTED_AT,
+    GITHUB_ACTION_REF,
 )
 
 from jacoco_report.model.report_group import ReportGroup
@@ -762,6 +765,27 @@ class ActionInputs:
         Get the repository from the GitHub environment variables.
         """
         return get_action_input("GITHUB_REPOSITORY", prefix="")
+
+    @staticmethod
+    def get_run_id() -> str:
+        """
+        Get the GitHub Actions run ID from environment variables.
+        """
+        return get_action_input(GITHUB_RUN_ID, prefix="")
+
+    @staticmethod
+    def get_run_started_at() -> str:
+        """
+        Get the ISO 8601 timestamp when the run started (GITHUB_RUN_STARTED_AT).
+        """
+        return get_action_input(GITHUB_RUN_STARTED_AT, prefix="")
+
+    @staticmethod
+    def get_action_ref() -> str:
+        """
+        Get the ref (tag/SHA) used to invoke this action (GITHUB_ACTION_REF).
+        """
+        return get_action_input(GITHUB_ACTION_REF, prefix="")
 
     @staticmethod
     def __parse_paths(paths: str) -> list[str]:

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -88,45 +88,72 @@ class PRCommentGenerator:
 
         body += f"\n\n{self.get_basic_table_for_all(p, f)}"
 
-        if comment_level == CommentLevelEnum.MINIMAL:
-            return title, body
+        if comment_level != CommentLevelEnum.MINIMAL:
+            filtered_groups = self.evaluator.evaluated_groups_coverage
+            filtered_reports = {
+                k: v for k, v in self.evaluator.evaluated_reports_coverage.items() if k not in self.skip_report_names
+            }
+            if self.skip_report_names:
+                visible_group_names: frozenset[str] = frozenset(
+                    v.group_name
+                    for k, v in self.evaluator.evaluated_reports_coverage.items()
+                    if k not in self.skip_report_names
+                )
+                filtered_groups = {k: v for k, v in filtered_groups.items() if k in visible_group_names}
 
-        filtered_groups = self.evaluator.evaluated_groups_coverage
-        filtered_reports = {
-            k: v for k, v in self.evaluator.evaluated_reports_coverage.items() if k not in self.skip_report_names
-        }
-        if self.skip_report_names:
-            visible_group_names: frozenset[str] = frozenset(
-                v.group_name
-                for k, v in self.evaluator.evaluated_reports_coverage.items()
-                if k not in self.skip_report_names
-            )
-            filtered_groups = {k: v for k, v in filtered_groups.items() if k in visible_group_names}
+            if comment_level != CommentLevelEnum.FULL:
+                filtered_groups = self._filter_evaluated_coverage_rows(filtered_groups, comment_level)
+                filtered_reports = self._filter_evaluated_coverage_rows(filtered_reports, comment_level)
 
-        if comment_level != CommentLevelEnum.FULL:
-            filtered_groups = self._filter_evaluated_coverage_rows(filtered_groups, comment_level)
-            filtered_reports = self._filter_evaluated_coverage_rows(filtered_reports, comment_level)
+            detail_sections: list[str] = []
 
-        detail_sections: list[str] = []
+            groups_table = self.get_groups_table(p, f, filtered_groups)
+            if groups_table:
+                detail_sections.append(groups_table)
 
-        groups_table = self.get_groups_table(p, f, filtered_groups)
-        if groups_table:
-            detail_sections.append(groups_table)
+            reports_table = self.get_reports_table(p, f, filtered_reports)
+            if reports_table:
+                detail_sections.append(reports_table)
 
-        reports_table = self.get_reports_table(p, f, filtered_reports)
-        if reports_table:
-            detail_sections.append(reports_table)
+            changed_files_table = self._get_changed_files_table(p, f, filtered_reports, comment_level)
+            if changed_files_table:
+                detail_sections.append(changed_files_table)
 
-        changed_files_table = self._get_changed_files_table(p, f, filtered_reports, comment_level)
-        if changed_files_table:
-            detail_sections.append(changed_files_table)
+            if detail_sections:
+                body += "\n\n" + "\n\n".join(detail_sections)
+            elif comment_level != CommentLevelEnum.FULL:
+                body += "\n\nNo rows match the selected comment level."
 
-        if detail_sections:
-            body += "\n\n" + "\n\n".join(detail_sections)
-        elif comment_level != CommentLevelEnum.FULL:
-            body += "\n\nNo rows match the selected comment level."
+        metadata = self._get_metadata_footer()
+        if metadata:
+            body += f"\n\n{metadata}"
 
         return title, body
+
+    def _get_metadata_footer(self) -> str:
+        """Build the metadata footer appended to every non-NONE PR comment."""
+        run_id = ActionInputs.get_run_id()
+        event = ActionInputs.get_event_name()
+        started_at = ActionInputs.get_run_started_at()
+        action_ref = ActionInputs.get_action_ref()
+
+        parts: list[str] = []
+        if run_id:
+            if self.github_repository:
+                url = f"https://github.com/{self.github_repository}/actions/runs/{run_id}"
+                parts.append(f"Run [{run_id}]({url})")
+            else:
+                parts.append(f"Run `{run_id}`")
+        if event:
+            parts.append(f"Event: `{event}`")
+        if action_ref:
+            parts.append(f"`{action_ref}`")
+        if started_at:
+            parts.append(started_at)
+
+        if not parts:
+            return ""
+        return "---\n*" + " · ".join(parts) + "*"
 
     def _filter_evaluated_coverage_rows(
         self,

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -147,9 +147,9 @@ class PRCommentGenerator:
         if event:
             parts.append(f"Event: `{event}`")
         if action_ref:
-            parts.append(f"`{action_ref}`")
+            parts.append(f"Action: `{action_ref}`")
         if started_at:
-            parts.append(started_at)
+            parts.append(f"Started: `{started_at}`")
 
         if not parts:
             return ""

--- a/jacoco_report/utils/constants.py
+++ b/jacoco_report/utils/constants.py
@@ -35,3 +35,8 @@ BASELINE_PATHS = "baseline-paths"
 OVERALL = "overall"
 CHANGED_FILES_AVERAGE = "changed-files-average"
 CHANGED_FILE = "changed-file"
+
+# GitHub-injected metadata environment variables (no INPUT_ prefix)
+GITHUB_RUN_ID = "GITHUB_RUN_ID"
+GITHUB_RUN_STARTED_AT = "GITHUB_RUN_STARTED_AT"
+GITHUB_ACTION_REF = "GITHUB_ACTION_REF"

--- a/tests/integration/fixtures/snapshot_no_groups.md
+++ b/tests/integration/fixtures/snapshot_no_groups.md
@@ -21,3 +21,6 @@
 |-----------|----------|-----------|--------|
 | [BigClass.java](https://github.com/owner/repo/pull/1/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 0.0% | ✅ |
 | [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |
+
+---
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*

--- a/tests/integration/fixtures/snapshot_no_groups.md
+++ b/tests/integration/fixtures/snapshot_no_groups.md
@@ -23,4 +23,4 @@
 | [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |
 
 ---
-*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · Action: `v3.0.0` · Started: `2025-01-01T00:00:00Z`*

--- a/tests/integration/fixtures/snapshot_skip_unchanged.md
+++ b/tests/integration/fixtures/snapshot_skip_unchanged.md
@@ -12,3 +12,6 @@
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
 | [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |
+
+---
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*

--- a/tests/integration/fixtures/snapshot_skip_unchanged.md
+++ b/tests/integration/fixtures/snapshot_skip_unchanged.md
@@ -14,4 +14,4 @@
 | [MidClass.java](https://github.com/owner/repo/pull/1/files#diff-3371f6a8118785a239bd8e06a35f29cab63074eddacfd456caecd1da1c68c2dd) | 90.83% | 0.0% | ✅ |
 
 ---
-*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · Action: `v3.0.0` · Started: `2025-01-01T00:00:00Z`*

--- a/tests/integration/fixtures/snapshot_with_groups.md
+++ b/tests/integration/fixtures/snapshot_with_groups.md
@@ -24,3 +24,6 @@
 |-----------|----------|-----------|--------|
 | [ApiClass.java](https://github.com/owner/repo/pull/1/files#diff-04de1cb2cf0087b2067d518ca69e0fa09d19ac3f70c216d9e6e95f539c22e217) | 95.0% | 0.0% | ✅ |
 | [ControllerClass.java](https://github.com/owner/repo/pull/1/files#diff-f31b78555f698136fc5a92f723c22aec2b1390402b08e26b0f355d028552546d) | 93.0% | 0.0% | ✅ |
+
+---
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*

--- a/tests/integration/fixtures/snapshot_with_groups.md
+++ b/tests/integration/fixtures/snapshot_with_groups.md
@@ -26,4 +26,4 @@
 | [ControllerClass.java](https://github.com/owner/repo/pull/1/files#diff-f31b78555f698136fc5a92f723c22aec2b1390402b08e26b0f355d028552546d) | 93.0% | 0.0% | ✅ |
 
 ---
-*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · `v3.0.0` · 2025-01-01T00:00:00Z*
+*Run [1111111111](https://github.com/owner/repo/actions/runs/1111111111) · Event: `pull_request` · Action: `v3.0.0` · Started: `2025-01-01T00:00:00Z`*

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -124,6 +124,9 @@ def make_env_base(**overrides: str) -> dict[str, str]:
         # GitHub-injected vars (no INPUT_ prefix)
         "GITHUB_EVENT_NAME": "pull_request",
         "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_RUN_ID": "1111111111",
+        "GITHUB_RUN_STARTED_AT": "2025-01-01T00:00:00Z",
+        "GITHUB_ACTION_REF": "v3.0.0",
         # Action inputs
         "INPUT_TOKEN": "ghs_" + "x" * 36,
         "INPUT_PATHS": TEST_PROJECT_GLOB,

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -863,55 +863,69 @@ def test_skip_report_names_hides_group_when_all_group_reports_are_skipped(pr_com
 # --- metadata footer ---
 
 def test_metadata_footer_all_fields(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="minimal")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="9876543210")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
     pr_comment_generator.github_repository = "owner/repo"
 
-    footer = pr_comment_generator._get_metadata_footer()
+    pr_comment_generator.generate()
 
-    assert "---" in footer
-    assert "Run [9876543210](https://github.com/owner/repo/actions/runs/9876543210)" in footer
-    assert "Event: `pull_request`" in footer
-    assert "`v3.0.0`" in footer
-    assert "2025-01-01T00:00:00Z" in footer
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+
+    assert "---" in body
+    assert "Run [9876543210](https://github.com/owner/repo/actions/runs/9876543210)" in body
+    assert "Event: `pull_request`" in body
+    assert "Action: `v3.0.0`" in body
+    assert "Started: `2025-01-01T00:00:00Z`" in body
 
 
 def test_metadata_footer_no_run_id(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="minimal")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
 
-    footer = pr_comment_generator._get_metadata_footer()
+    pr_comment_generator.generate()
 
-    assert "Run" not in footer
-    assert "Event: `pull_request`" in footer
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+
+    assert "Run" not in body
+    assert "Event: `pull_request`" in body
+    assert "Action: `v3.0.0`" in body
+    assert "Started: `2025-01-01T00:00:00Z`" in body
 
 
 def test_metadata_footer_all_empty_returns_empty_string(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="minimal")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="")
 
-    footer = pr_comment_generator._get_metadata_footer()
+    pr_comment_generator.generate()
 
-    assert footer == ""
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+
+    assert "\n\n---\n*" not in body
 
 
 def test_metadata_footer_run_id_without_repository(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="minimal")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="42")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="")
     pr_comment_generator.github_repository = ""
 
-    footer = pr_comment_generator._get_metadata_footer()
+    pr_comment_generator.generate()
 
-    assert "Run `42`" in footer
-    assert "github.com" not in footer
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+
+    assert "Run `42`" in body
+    assert "github.com" not in body
 
 
 def test_metadata_footer_appended_to_comment_body(pr_comment_generator, mocker):
@@ -928,8 +942,8 @@ def test_metadata_footer_appended_to_comment_body(pr_comment_generator, mocker):
     assert "---" in body
     assert "Run [9876543210]" in body
     assert "Event: `pull_request`" in body
-    assert "`v3.0.0`" in body
-    assert "2025-01-01T00:00:00Z" in body
+    assert "Action: `v3.0.0`" in body
+    assert "Started: `2025-01-01T00:00:00Z`" in body
 
 
 def test_metadata_footer_not_appended_for_none_level(pr_comment_generator, mocker):

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -858,3 +858,88 @@ def test_skip_report_names_hides_group_when_all_group_reports_are_skipped(pr_com
     assert "`backend`" not in body
     assert "`frontend-report`" in body
     assert "`backend-report`" not in body
+
+
+# --- metadata footer ---
+
+def test_metadata_footer_all_fields(pr_comment_generator, mocker):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="9876543210")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
+    pr_comment_generator.github_repository = "owner/repo"
+
+    footer = pr_comment_generator._get_metadata_footer()
+
+    assert "---" in footer
+    assert "Run [9876543210](https://github.com/owner/repo/actions/runs/9876543210)" in footer
+    assert "Event: `pull_request`" in footer
+    assert "`v3.0.0`" in footer
+    assert "2025-01-01T00:00:00Z" in footer
+
+
+def test_metadata_footer_no_run_id(pr_comment_generator, mocker):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
+
+    footer = pr_comment_generator._get_metadata_footer()
+
+    assert "Run" not in footer
+    assert "Event: `pull_request`" in footer
+
+
+def test_metadata_footer_all_empty_returns_empty_string(pr_comment_generator, mocker):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="")
+
+    footer = pr_comment_generator._get_metadata_footer()
+
+    assert footer == ""
+
+
+def test_metadata_footer_run_id_without_repository(pr_comment_generator, mocker):
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="42")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="")
+    pr_comment_generator.github_repository = ""
+
+    footer = pr_comment_generator._get_metadata_footer()
+
+    assert "Run `42`" in footer
+    assert "github.com" not in footer
+
+
+def test_metadata_footer_appended_to_comment_body(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="minimal")
+    pr_comment_generator.github_repository = "owner/repo"
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="9876543210")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
+
+    pr_comment_generator.generate()
+
+    body = pr_comment_generator.gh.add_comment.call_args[0][1]
+    assert "---" in body
+    assert "Run [9876543210]" in body
+    assert "Event: `pull_request`" in body
+    assert "`v3.0.0`" in body
+    assert "2025-01-01T00:00:00Z" in body
+
+
+def test_metadata_footer_not_appended_for_none_level(pr_comment_generator, mocker):
+    _configure_generator_for_comment_tests(pr_comment_generator, mocker, comment_level="none")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value="9876543210")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value="pull_request")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
+
+    _, body = pr_comment_generator._get_comment_content("none")
+
+    assert "---" not in body
+    assert "Run" not in body

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -953,7 +953,6 @@ def test_metadata_footer_not_appended_for_none_level(pr_comment_generator, mocke
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value="2025-01-01T00:00:00Z")
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value="v3.0.0")
 
-    _, body = pr_comment_generator._get_comment_content("none")
+    pr_comment_generator.generate()
 
-    assert "---" not in body
-    assert "Run" not in body
+    pr_comment_generator.gh.add_comment.assert_not_called()

--- a/tests/unit/test_jacoco_report.py
+++ b/tests/unit/test_jacoco_report.py
@@ -23,7 +23,10 @@ comment_no_data_no_baseline = """**JaCoCo Coverage Report**
 | File Path | Coverage | Threshold | Status |
 |-----------|----------|-----------|--------|
 
-No changed file in reports."""
+No changed file in reports.
+
+---
+*Event: `pull_request`*"""
 
 comment_no_data_with_baseline = """**JaCoCo Coverage Report**
 
@@ -39,7 +42,10 @@ comment_no_data_with_baseline = """**JaCoCo Coverage Report**
 | File Path | Coverage | Threshold | Δ Coverage | Status |
 |-----------|----------|-----------|------------|--------|
 
-No changed file in reports."""
+No changed file in reports.
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_detailed = """TODO"""
 comment_one_file_multi_detailed = """TODO"""
@@ -54,42 +60,60 @@ comment_one_file_single_minimalist_instruction = """**Custom Title**
 | Metric (instruction) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 90.0% | 0.0% | ✅ |
-| **Changed Files** | 80.0% | 0.0% | ✅ |"""
+| **Changed Files** | 80.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_minimalist_line = """**Custom Title**
 
 | Metric (line) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 80.0% | 0.0% | ✅ |
-| **Changed Files** | 60.0% | 0.0% | ✅ |"""
+| **Changed Files** | 60.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_minimalist_branch = """**Custom Title**
 
 | Metric (branch) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 75.0% | 0.0% | ✅ |
-| **Changed Files** | 0.0% | 0.0% | ✅ |"""
+| **Changed Files** | 0.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_minimalist_complexity = """**Custom Title**
 
 | Metric (complexity) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 75.0% | 0.0% | ✅ |
-| **Changed Files** | 50.0% | 0.0% | ✅ |"""
+| **Changed Files** | 50.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_minimalist_method = """**Custom Title**
 
 | Metric (method) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 100.0% | 0.0% | ✅ |
-| **Changed Files** | 0.0% | 0.0% | ✅ |"""
+| **Changed Files** | 0.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_single_minimalist_class = """**Custom Title**
 
 | Metric (class) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**       | 100.0% | 0.0% | ✅ |
-| **Changed Files** | 0.0% | 0.0% | ✅ |"""
+| **Changed Files** | 0.0% | 0.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_one_file_multi_minimalist = """TODO"""
 comment_one_file_module_minimalist = """TODO"""
@@ -273,7 +297,10 @@ comment_more_files_single_detailed_instruction_no_modules = """**JaCoCo Coverage
 |-----------|----------|-----------|--------|
 | [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | ✅ |
 | [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |"""
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_more_files_single_detailed_instruction_no_modules_with_bs = """**JaCoCo Coverage Report**
 
@@ -298,7 +325,10 @@ comment_more_files_single_detailed_instruction_no_modules_with_bs = """**JaCoCo 
 |-----------|----------|-----------|------------|--------|
 | [BigClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-ead3b50565c5dda5dc7e32be690e80a71f6e317d66aaa386b5942b484476832d) | 90.0% | 65.0% | -5.0% | ✅ |
 | [ClientHttpClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-233a8df372c1ee3631d77bd1afb2eb2c5729cdb125b277a3b0eb51a4933b888a) | 90.0% | 65.0% | +80.0% | ✅ |
-| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |"""
+| [ImplementationClass.java](https://github.com/MoranaApps/jacoco-report/pull/35/files#diff-7a267b2f062048b58eaf9c03df9857a0b95e8425451a7a68e18508a2ccb0d316) | 88.0% | 65.0% | +8.0% | ✅ |
+
+---
+*Event: `pull_request`*"""
 
 comment_more_files_single_detailed_instruction_with_modules = """**JaCoCo Coverage Report**
 

--- a/tests/unit/test_jacoco_report.py
+++ b/tests/unit/test_jacoco_report.py
@@ -2117,6 +2117,9 @@ def test_run_with_report_groups_explicit_empty_baseline_does_not_inherit_global(
 
 def test_run_successful_empty_no_baseline(jacoco_report, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value='')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
     mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=[f'{os.getcwd()}/tests/data/module_b/target/jacoco_no_data.xml'])
@@ -2135,6 +2138,9 @@ def test_run_successful_empty_no_baseline(jacoco_report, mocker):
 
 def test_run_successful_empty_with_baseline(jacoco_report, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value='')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_baseline_paths", return_value=['fake/path'])
     mocker.patch("jacoco_report.utils.github.GitHub.get_pr_number", return_value=35)
@@ -2165,6 +2171,9 @@ one_source_file_scenarios = [
 @pytest.mark.parametrize("metric, comment, ov_cov, ch_cov, ov_cov_b, ch_cov_b", one_source_file_scenarios)
 def test_successful_one_source_file (jacoco_report, metric, comment, ov_cov, ch_cov, ov_cov_b, ch_cov_b, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value='')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_title", return_value='Custom Title')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value=metric)
@@ -2197,6 +2206,9 @@ more_source_files_scenarios = [
 @pytest.mark.parametrize("id, level, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_groups, violations, skip_unchanged, use_baseline", more_source_files_scenarios)
 def test_successful_more_source_files(jacoco_report, id, level, changed_files, expected_comments, evaluated_cov_reports, evaluated_cov_groups, violations, skip_unchanged, use_baseline, mocker):
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_event_name", return_value='pull_request')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_id", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_action_ref", return_value='')
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_run_started_at", return_value='')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_token", return_value='fake_token')
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_comment_level", return_value=level)
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_paths", return_value=["tests/data/test_project/**/jacoco.xml"])


### PR DESCRIPTION

## Changes

| File | What changed |
|------|-------------|
| `jacoco_report/utils/constants.py` | Added `GITHUB_RUN_ID`, `GITHUB_RUN_STARTED_AT`, `GITHUB_ACTION_REF` constants |
| `jacoco_report/action_inputs.py` | Added `get_run_id()`, `get_run_started_at()`, `get_action_ref()` static methods |
| `jacoco_report/generator/pr_comment_generator.py` | Added `_get_metadata_footer()`; refactored `_get_comment_content` to append it for all non-`none` levels |
| `tests/integration/helpers.py` | Added deterministic metadata env vars to `make_env_base` |
| `tests/integration/fixtures/snapshot_*.md` | Regenerated golden snapshots to include footer |
| `tests/unit/generator/test_pr_comment_generator.py` | 6 new tests for `_get_metadata_footer` |
| `tests/unit/test_jacoco_report.py` | Updated 10 exact-match expected comment strings |

## Behaviour notes

- `comment-level: none` — no comment is posted, no footer is generated
- All other levels — footer is appended after the last table/message
- `GITHUB_RUN_ID` without `GITHUB_REPOSITORY` renders as plain `` `run-id` `` (no link)
- Footer is omitted when all four env vars are empty (e.g., local dev without GitHub context)

## Test plan

- [x] `pytest tests/ --cov=jacoco_report --cov-fail-under=80` — 377 passed, 96.72% coverage
- [x] `mypy .` — no issues
- [x] `black --check` — no issues
- [x] `pylint jacoco_report/ main.py` — 9.97/10 (pre-existing warnings only)
- [x] Golden snapshots regenerated and verified
- [x] Unit tests cover: all fields present, missing run ID, no repository, all empty (no footer), footer not rendered for `none` level

## Related

Closes #94 

Release Notes:

- PR comments now include a metadata footer for traceability — linked run ID, trigger event, action version, and start timestamp
