### PR TITLE
feat(docs): Enhance documentation and examples for JaCoCo Report GitH…

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -62,7 +62,7 @@ chmod +x run_script.sh
 ```bash
 #!/bin/sh
 
-export INPUT_TOKEN="ghp_your_personal_access_token"
+# INPUT_TOKEN must be provided externally, e.g.:
 export INPUT_PATHS="**/jacoco.xml"
 export INPUT_EXCLUDE_PATHS=""
 export INPUT_GLOBAL_THRESHOLDS="80*70*0"
@@ -94,7 +94,7 @@ python3 main.py
 ```bash
 #!/bin/sh
 
-export INPUT_TOKEN="ghp_your_personal_access_token"
+# INPUT_TOKEN must be provided externally, e.g.:
 export INPUT_GLOBAL_THRESHOLDS="80*70*0"
 export INPUT_REPORT_THRESHOLDS_DEFAULT="75*60*0"
 export INPUT_COMMENT_LEVEL="full"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,24 +1,30 @@
-# Jacoco Report GitHub Action - Developer Guide
+# Jacoco Report GitHub Action — Developer Guide
 
 - [Project Setup](#project-setup)
+- [Branch Naming Convention](#branch-naming-convention)
 - [Run Scripts Locally](#run-scripts-locally)
 - [Run Pylint Check Locally](#run-pylint-check-locally)
 - [Run Black Tool Locally](#run-black-tool-locally)
-- [Run Unit Test](#run-unit-test)
+- [Run Mypy Locally](#run-mypy-locally)
+- [Run Tests](#run-tests)
+  - [Unit Tests](#unit-tests)
+  - [Integration Tests (offline)](#integration-tests-offline)
+  - [Live Integration Tests](#live-integration-tests)
+  - [Regenerate Golden Snapshots](#regenerate-golden-snapshots)
 - [Code Coverage](#code-coverage)
 - [Releasing](#releasing)
 
-## Project Setup
+---
 
-If you need to build the action locally, follow these steps for project setup:
+## Project Setup
 
 ### Prepare the Environment
 
 ```shell
-python3 --version
+python3 --version   # Python 3.13+ required
 ```
 
-### Set Up Python Environment
+### Set Up Python Virtual Environment
 
 ```shell
 python3 -m venv .venv
@@ -28,68 +34,93 @@ pip install -r requirements.txt
 
 ---
 
+## Branch Naming Convention
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/<issue-number>-<short-description>` | `feature/112-skip-unchanged-filter` |
+| Bug fix | `fix/<issue-number>-<short-description>` | `fix/95-remove-pylint-disables` |
+| Docs | `docs/<short-description>` | `docs/update-developer-md` |
+| Chore | `chore/<short-description>` | `chore/add-fixture-factories` |
+| Spike | `spike/<issue-number>-<short-description>` | `spike/71-auto-detect-modules` |
+
+---
+
 ## Run Scripts Locally
 
-If you need to run the scripts locally, follow these steps:
+Create a shell script in the project root to simulate a GitHub Actions run locally.
 
 ### Create the Shell Script
 
-Create the shell file in the root directory. We will use `run_script.sh`.
-
 ```shell
 touch run_script.sh
+chmod +x run_script.sh
 ```
 
-Add the shebang line at the top of the sh script file.
+### Minimal script (no groups)
 
 ```bash
 #!/bin/sh
 
-# Essential environment variables for GitHub Action functionality
-export INPUT_PATHS="jacoco.xml"
-export INPUT_EXCLUDES="tests/*"
-export INPUT_BASELINE_PATHS='
-tests/data_baseline/**/*.xml
-'
-
-export INPUT_TITLE="Code Coverage Report"
-
-export INPUT_GLOBAL_THRESHOLDS="80*80*80"
-
-export INPUT_PR_NUMBER="1"                  # Required to add the PR number to receive the comments
-
-export INPUT_METRICS="instruction"
+export INPUT_TOKEN="ghp_your_personal_access_token"
+export INPUT_PATHS="**/jacoco.xml"
+export INPUT_EXCLUDE_PATHS=""
+export INPUT_GLOBAL_THRESHOLDS="80*70*60"
+export INPUT_REPORT_THRESHOLDS_DEFAULT="0*0*0"
+export INPUT_TITLE="JaCoCo Coverage Report"
+export INPUT_PR_NUMBER="1"
+export INPUT_METRIC="instruction"
 export INPUT_COMMENT_LEVEL="full"
-
-export INPUT_MODULES='
-module_large: test_project/module_large
-'
-export INPUT_MODULES_THRESHOLDS='
-module_large:80.0*95.0
-'
-
-export INPUT_SKIP_NOT_CHANGED="false"
+export INPUT_REPORT_GROUPS=""
+export INPUT_SKIP_UNCHANGED="false"
+export INPUT_EVALUATE_UNCHANGED="true"
+export INPUT_BASELINE_PATHS=""
 export INPUT_UPDATE_COMMENT="false"
-export INPUT_FAIL_ON_THRESHOLD="false"
-export INPUT_DEBUG="false"
-
+export INPUT_FAIL_ON_THRESHOLD="overall,changed-files-average,per-changed-file"
 export INPUT_PASS_SYMBOL="✅"
 export INPUT_FAIL_SYMBOL="❌"
+export INPUT_DEBUG="false"
 
-# Required Variables defined by GitHub - extras for local testing
+# Required GitHub context variables
 export GITHUB_REPOSITORY="MoranaApps/jacoco-report-dev"
 export GITHUB_EVENT_NAME="pull_request"
-export GITHUB_REF="refs/pull/35/merge"
+export GITHUB_REF="refs/pull/1/merge"
 
 python3 main.py
 ```
 
-### Make the Script Executable
+### Script with report groups
 
-From the terminal that is in the root of this project, make the script executable:
+```bash
+#!/bin/sh
 
-```shell
-chmod +x run_script.sh
+export INPUT_TOKEN="ghp_your_personal_access_token"
+export INPUT_GLOBAL_THRESHOLDS="80*70*60"
+export INPUT_REPORT_THRESHOLDS_DEFAULT="75*60*0"
+export INPUT_COMMENT_LEVEL="full"
+export INPUT_REPORT_GROUPS="
+- name: backend
+  paths:
+    - backend/**/jacoco.xml
+  thresholds: '80*70*60'
+- name: frontend
+  paths:
+    - frontend/**/jacoco.xml
+  thresholds: '75*65*50'
+"
+export INPUT_SKIP_UNCHANGED="false"
+export INPUT_EVALUATE_UNCHANGED="true"
+export INPUT_UPDATE_COMMENT="false"
+export INPUT_FAIL_ON_THRESHOLD="overall,changed-files-average,per-changed-file"
+export INPUT_PASS_SYMBOL="✅"
+export INPUT_FAIL_SYMBOL="❌"
+export INPUT_DEBUG="true"
+
+export GITHUB_REPOSITORY="MoranaApps/jacoco-report-dev"
+export GITHUB_EVENT_NAME="pull_request"
+export GITHUB_REF="refs/pull/1/merge"
+
+python3 main.py
 ```
 
 ### Run the Script
@@ -102,154 +133,153 @@ chmod +x run_script.sh
 
 ## Run Pylint Check Locally
 
-This project uses [Pylint](https://pypi.org/project/pylint/) tool for static code analysis.
-Pylint analyses your code without actually running it.
-It checks for errors, enforces, coding standards, looks for code smells etc.
-We do exclude the `tests/` file from the pylint check.
-
-Pylint displays a global evaluation score for the code, rated out of a maximum score of 10.0.
-We are aiming to keep our code quality high above the score 9.5.
-
-Follow these steps to run Pylint check locally:
-
-### Set Up Python Environment
-
-From terminal in the root of the project, run the following command:
-
-```shell
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-```
-
-This command will also install a Pylint tool, since it is listed in the project requirements.
-
-### Run Pylint
-
-Run Pylint on all files that are currently tracked by Git in the project.
+This project uses [Pylint](https://pypi.org/project/pylint/) for static code analysis.
+Configuration is in `.pylintrc`. The target score is ≥ 9.5/10.
 
 ```shell
 pylint $(git ls-files '*.py')
 ```
 
-To run Pylint on a specific file, follow the pattern `pylint <path_to_file>/<name_of_file>.py`.
-
-Example:
+To lint a single file:
 
 ```shell
 pylint jacoco_report/jacoco_report.py
 ```
 
-### Expected Output
+Expected output example:
 
-This is the console expected output example after running the tool:
-
-```shell
-************* Module main
-main.py:30:0: C0116: Missing function or method docstring (missing-function-docstring)
-
+```
 ------------------------------------------------------------------
-Your code has been rated at 9.41/10 (previous run: 8.82/10, +0.59)
+Your code has been rated at 9.67/10 (previous run: 9.67/10, +0.00)
 ```
 
 ---
 
 ## Run Black Tool Locally
 
-This project uses the [Black](https://github.com/psf/black) tool for code formatting.
-Black aims for consistency, generality, readability and reducing git diffs.
-The coding style used can be viewed as a strict subset of PEP 8.
+This project uses [Black](https://github.com/psf/black) for code formatting (line length 120,
+target Python 3.12). Configuration is in `pyproject.toml`.
 
-The project root file `pyproject.toml` defines the Black tool configuration.
-In this project we are accepting the line length of 120 characters.
-We also do exclude the `tests/` file from the black formatting.
-
-Follow these steps to format your code with Black locally:
-
-### Set Up Python Environment
-
-From terminal in the root of the project, run the following command:
+Check formatting without modifying files:
 
 ```shell
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+black --check $(git ls-files '*.py')
 ```
 
-This command will also install a Black tool, since it is listed in the project requirements.
-
-### Run Black
-
-Run Black on all files that are currently tracked by Git in the project.
+Apply formatting:
 
 ```shell
 black $(git ls-files '*.py')
 ```
 
-To run Black on a specific file, follow the pattern `black <path_to_file>/<name_of_file>.py`.
+---
 
-Example:
+## Run Mypy Locally
 
-```shell
-black jacoco_report/jacoco_report.py
-```
-
-### Expected Output
-
-This is the console expected output example after running the tool:
+This project uses [mypy](https://mypy.readthedocs.io/) for static type checking.
+Configuration is in `pyproject.toml`.
 
 ```shell
-All done! ✨ 🍰 ✨
-1 file reformatted.
+mypy .
 ```
+
+All source files must pass with zero errors before merging.
 
 ---
 
-## Run Unit Test
+## Run Tests
 
-Unit tests are written using the Pytest framework. To run all the tests, use the following command:
+### Unit Tests
+
+Unit tests cover individual functions and classes in isolation.
 
 ```shell
 pytest tests/unit/
 ```
 
-You can modify the directory to control the level of detail or granularity as per your needs.
-
-To run a specific test, write the command following the pattern below:
+Run a specific test:
 
 ```shell
-pytest tests/unit/utils/test_github.py::test_send_request_get
+pytest tests/unit/evaluator/test_coverage_evaluator.py::test_overall_threshold
 ```
+
+### Integration Tests (offline)
+
+Integration tests exercise the full action pipeline without a GitHub token.
+They use fixture XML files from `tests/data/` and `tests/data_baseline/`.
+
+```shell
+pytest tests/integration/ --ignore=tests/integration/live
+```
+
+These tests include:
+
+- **Golden snapshot tests** (`test_golden_snapshots.py`): assert that the generated PR comment
+  matches a stored golden file in `tests/integration/fixtures/`.
+- **Matrix tests** (`test_matrix_skip_unchanged_comment_level.py`): verify all
+  `skip-unchanged` × `comment-level` combinations (12 cases).
+
+### Live Integration Tests
+
+Live tests post a real comment to a GitHub PR and require a valid `GITHUB_TOKEN`.
+They are skipped automatically on forks.
+
+```shell
+GITHUB_TOKEN=ghp_... pytest tests/integration/live/
+```
+
+In CI these run only when `github.event.pull_request.head.repo.full_name == github.repository`.
+
+### Regenerate Golden Snapshots
+
+When the PR comment output intentionally changes (e.g. after a feature update), regenerate the
+golden snapshot files instead of manually editing them:
+
+```shell
+WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py
+```
+
+This writes the current action output to `tests/integration/fixtures/snapshot_*.md`.
+Commit the updated files alongside your feature change.
 
 ---
 
 ## Code Coverage
 
-This project uses [pytest-cov](https://pypi.org/project/pytest-cov/) plugin to generate test coverage reports.
-The objective of the project is to achieve a minimal score of 80 %. We do exclude the `tests/` file from the coverage
-report.
+This project uses [pytest-cov](https://pypi.org/project/pytest-cov/). The minimum coverage
+threshold is **80 %** (measured over `tests/unit/` and `tests/integration/` combined,
+excluding `tests/integration/live/`).
 
-To generate the coverage report, run the following command:
+Generate a coverage report:
 
 ```shell
-pytest tests/unit/ --cov=. --cov-fail-under=80 --cov-report=html -vv
+pytest --cov=. tests/ --ignore=tests/integration/live --cov-fail-under=80 --cov-report=html -vv
 ```
 
-See the coverage report on the path:
+Open the report:
 
 ```shell
 open htmlcov/index.html
+```
+
+Full QA gate (mirrors CI):
+
+```shell
+pytest --cov=. tests/ --cov-fail-under=80 && \
+pylint $(git ls-files '*.py') && \
+black --check $(git ls-files '*.py') && \
+mypy .
 ```
 
 ---
 
 ## Releasing
 
-This project uses GitHub Actions for deployment draft creation. The deployment process is semi-automated by a workflow
-defined in `.github/workflows/release_draft.yml`.
+This project uses GitHub Actions for release draft creation via `.github/workflows/release_draft.yml`.
 
-- **Trigger the workflow**: The `release_draft.yml` workflow is triggered on workflow_dispatch.
-- **Create a new draft release**: The workflow creates a new draft release in the repository.
-- **Finalize the release draft**: Edit the draft release to add a title, description, and any other necessary details
-related to GitHub Action.
-- **Publish the release**: Once the draft is ready, publish the release to make it available to the public.
+1. **Trigger the workflow** — run `release_draft.yml` via `workflow_dispatch`.
+2. **Review the draft release** — add a title, description, and changelog notes.
+3. **Publish the release** — once the draft is finalised, publish it.
+
+The `v2` tag is kept in sync automatically by `.github/workflows/update-v2-tag.yml` after each
+release to `v2.x.y`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -267,7 +267,7 @@ Open the report:
 open htmlcov/index.html
 ```
 
-Full QA gate (mirrors CI):
+Full local QA gate (stricter single command):
 
 ```shell
 pytest --cov=. tests/ --ignore=tests/integration/live --cov-fail-under=80 && \

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -65,8 +65,8 @@ chmod +x run_script.sh
 export INPUT_TOKEN="ghp_your_personal_access_token"
 export INPUT_PATHS="**/jacoco.xml"
 export INPUT_EXCLUDE_PATHS=""
-export INPUT_GLOBAL_THRESHOLDS="80*70*60"
-export INPUT_REPORT_THRESHOLDS_DEFAULT="0*0*0"
+export INPUT_GLOBAL_THRESHOLDS="80*70*0"
+export INPUT_REPORT_THRESHOLDS_DEFAULT="0*0*60"
 export INPUT_TITLE="JaCoCo Coverage Report"
 export INPUT_PR_NUMBER="1"
 export INPUT_METRIC="instruction"
@@ -95,7 +95,7 @@ python3 main.py
 #!/bin/sh
 
 export INPUT_TOKEN="ghp_your_personal_access_token"
-export INPUT_GLOBAL_THRESHOLDS="80*70*60"
+export INPUT_GLOBAL_THRESHOLDS="80*70*0"
 export INPUT_REPORT_THRESHOLDS_DEFAULT="75*60*0"
 export INPUT_COMMENT_LEVEL="full"
 export INPUT_REPORT_GROUPS="

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,4 +1,4 @@
-# Jacoco Report GitHub Action — Developer Guide
+# JaCoCo Report GitHub Action — Developer Guide
 
 - [Project Setup](#project-setup)
 - [Branch Naming Convention](#branch-naming-convention)
@@ -110,6 +110,7 @@ export INPUT_REPORT_GROUPS="
 "
 export INPUT_SKIP_UNCHANGED="false"
 export INPUT_EVALUATE_UNCHANGED="true"
+export INPUT_PR_NUMBER="1"
 export INPUT_UPDATE_COMMENT="false"
 export INPUT_FAIL_ON_THRESHOLD="overall,changed-files-average,per-changed-file"
 export INPUT_PASS_SYMBOL="✅"
@@ -134,7 +135,7 @@ python3 main.py
 ## Run Pylint Check Locally
 
 This project uses [Pylint](https://pypi.org/project/pylint/) for static code analysis.
-Configuration is in `.pylintrc`. The target score is ≥ 9.5/10.
+Configuration is in `.pylintrc`. The target score is **10.0/10** (`fail-under=10`).
 
 ```shell
 pylint $(git ls-files '*.py')
@@ -148,9 +149,9 @@ pylint jacoco_report/jacoco_report.py
 
 Expected output example:
 
-```
+```text
 ------------------------------------------------------------------
-Your code has been rated at 9.67/10 (previous run: 9.67/10, +0.00)
+Your code has been rated at 10.00/10
 ```
 
 ---
@@ -158,7 +159,7 @@ Your code has been rated at 9.67/10 (previous run: 9.67/10, +0.00)
 ## Run Black Tool Locally
 
 This project uses [Black](https://github.com/psf/black) for code formatting (line length 120,
-target Python 3.12). Configuration is in `pyproject.toml`.
+target Python 3.13). Configuration is in `pyproject.toml`.
 
 Check formatting without modifying files:
 
@@ -200,7 +201,7 @@ pytest tests/unit/
 Run a specific test:
 
 ```shell
-pytest tests/unit/evaluator/test_coverage_evaluator.py::test_overall_threshold
+pytest tests/unit/evaluator/test_coverage_evaluator.py::test_evaluate_overall_coverage
 ```
 
 ### Integration Tests (offline)
@@ -221,11 +222,15 @@ These tests include:
 
 ### Live Integration Tests
 
-Live tests post a real comment to a GitHub PR and require a valid `GITHUB_TOKEN`.
+Live tests post a real comment to a GitHub PR and require `GITHUB_TOKEN`, `GITHUB_REPOSITORY`,
+and a PR-shaped `GITHUB_REF` (`refs/pull/<n>/merge`).
 They are skipped automatically on forks.
 
 ```shell
-GITHUB_TOKEN=ghp_... pytest tests/integration/live/
+GITHUB_TOKEN=ghp_... \
+GITHUB_REPOSITORY=owner/repo \
+GITHUB_REF=refs/pull/123/merge \
+pytest tests/integration/live/
 ```
 
 In CI these run only when `github.event.pull_request.head.repo.full_name == github.repository`.
@@ -265,7 +270,7 @@ open htmlcov/index.html
 Full QA gate (mirrors CI):
 
 ```shell
-pytest --cov=. tests/ --cov-fail-under=80 && \
+pytest --cov=. tests/ --ignore=tests/integration/live --cov-fail-under=80 && \
 pylint $(git ls-files '*.py') && \
 black --check $(git ls-files '*.py') && \
 mypy .
@@ -281,5 +286,5 @@ This project uses GitHub Actions for release draft creation via `.github/workflo
 2. **Review the draft release** — add a title, description, and changelog notes.
 3. **Publish the release** — once the draft is finalised, publish it.
 
-The `v2` tag is kept in sync automatically by `.github/workflows/update-v2-tag.yml` after each
-release to `v2.x.y`.
+The `v2` tag is moved automatically by `.github/workflows/update-v2-tag.yml` on every
+published release.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub tag](https://img.shields.io/github/v/tag/MoranaApps/jacoco-report?label=latest&style=flat-square&color=blue)
 
 - [Motivation](#motivation)
+- [Requirements](#requirements)
 - [Quick Start](#quick-start)
 - [Usage](#usage)
   - [Action Inputs](#action-inputs)
@@ -30,7 +31,7 @@ which files changed, what their coverage is, and whether thresholds are met, wit
 
 Key capabilities:
 
-- **Global thresholds** — enforce overall, average-changed, and per-file minimums in one input.
+- **Global thresholds** — enforce overall and average-changed minimums in one input.
 - **Report groups** — organise multi-module projects into named groups with per-group thresholds.
 - **Baseline comparison** — show Δ coverage against a stored baseline (e.g. `main` branch reports).
 - **Flexible comment levels** — from a single-line summary to full per-file detail, or no comment at all.
@@ -43,12 +44,18 @@ Key capabilities:
 Add the following step to any job that already produces a JaCoCo XML report:
 
 ```yaml
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
     token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco.xml'
-    global-thresholds: '80*70*60'   # overall * changed-avg * per-file
+    global-thresholds: '80*70*0'        # overall * changed-avg * reserved-third
+    report-thresholds-default: '0*0*60' # per-changed-file threshold
 ```
 
 This posts a full PR comment and fails the action if any threshold is not met.
@@ -101,7 +108,7 @@ jobs:
 | `token`             | GitHub token for authentication with the repository.                                                                                                                                                                           | **Yes**  |                                                  |
 | `paths`             | Newline-separated paths to JaCoCo XML files. Supports wildcard glob patterns. Required when `report-groups` is not set.                                                                                                        | No       | `''`                                             |
 | `exclude-paths`     | Newline-separated paths to exclude from coverage analysis. Supports glob patterns.                                                                                                                                             | No       | `''`                                             |
-| `global-thresholds` | Global coverage thresholds in `overall*changed-files-average*per-changed-file` format. Evaluated independently as a separate pass over aggregated totals.                                                                      | No       | `0.0*0.0*0.0`                                    |
+| `global-thresholds` | Global thresholds in `overall*changed-files-average*reserved-third` format. Aggregated evaluation uses overall and changed-files-average.                                                                                         | No       | `0.0*0.0*0.0`                                    |
 | `report-thresholds-default` | Default thresholds for reports/groups when a group omits a threshold field. Format: `overall*changed-files-average*per-changed-file` (e.g. `75*60*0`). Field-level fallback chain: per-group → this default → 0.0.        | No       | `0.0*0.0*0.0`                                    |
 | `title`             | Title for the coverage report comment added to the Pull Request.                                                                                                                                                               | No       | `JaCoCo Coverage Report`                         |
 | `pr-number`         | Number of the pull request. If not provided, the action will attempt to determine the PR number from the GitHub context.                                                                                                       | No       | `''`                                             |
@@ -119,6 +126,9 @@ jobs:
 
 > Hint: default values have been defined to provide maximal possible information in the comment.
 
+Per-changed-file checks are configured by `report-thresholds-default` or per-group `thresholds`,
+not by `global-thresholds`.
+
 ---
 
 #### Outputs
@@ -127,10 +137,12 @@ The following outputs are set by the JaCoCo GitHub Action:
 
 - `coverage-overall`: The overall code coverage percentage.
 - `coverage-changed-files`: The code coverage percentage for the changed files.
-- `coverage-overall-passed`: A boolean indicating if the overall code coverage meets the minimum threshold.
-- `coverage-changed-files-passed`: A boolean indicating if the code coverage for the changed files meets the minimum threshold.
+- `coverage-overall-passed`: A boolean indicating if overall code coverage meets the configured threshold.
+- `coverage-changed-files-passed`: A boolean indicating if changed-files average coverage
+  meets the configured threshold.
 - `reports-coverage`: A JSON string containing the evaluated coverage per report.
-- `groups-coverage`: A JSON string containing the evaluated coverage per report group (populated when `report-groups` is defined).
+- `groups-coverage`: A JSON string containing the evaluated coverage per report group
+  (populated when `report-groups` is defined).
 
 ---
 
@@ -181,8 +193,11 @@ analysis.
 
 #### Customizing the Global Coverage Thresholds
 
-The `global-thresholds` input defines coverage thresholds for the aggregated totals in the format
-`overall*changed-files-average*per-changed-file`.
+The `global-thresholds` input defines aggregated thresholds in the format
+`overall*changed-files-average*reserved-third`.
+
+Per-changed-file enforcement is configured through `report-thresholds-default` (or per-group
+`thresholds` when `report-groups` is used).
 
 ```yaml
 - name: Publish JaCoCo Report
@@ -190,7 +205,8 @@ The `global-thresholds` input defines coverage thresholds for the aggregated tot
   with:
     token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    global-thresholds: '80*70*60'   # 80% overall, 70% changed avg, 60% per file
+    global-thresholds: '80*70*0'    # 80% overall, 70% changed avg
+    report-thresholds-default: '0*0*60' # 60% per changed file
     fail-on-threshold: 'overall,changed-files-average,per-changed-file'
 ```
 
@@ -240,15 +256,22 @@ The `report-groups` input groups JaCoCo reports under named groups with optional
 baseline paths. When defined, each group's `paths` is used for scanning and the top-level `paths` input can be omitted.
 
 Each entry is a YAML mapping with:
+
 - `name` (required): Group name shown in the PR comment groups table.
 - `paths` (required): List of glob patterns for JaCoCo XML reports in this group.
-- `thresholds` (optional): `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Missing fields fall back to `report-thresholds-default`, then to 0.0. Global thresholds are a separate evaluation pass.
-- `baseline-paths` (optional): List of glob patterns for baseline reports for this group. Falls back to top-level `baseline-paths` only when exactly one group omits `baseline-paths`; when multiple groups omit it, baseline inheritance is treated as ambiguous and skipped for those groups.
+- `thresholds` (optional): `overall*changed-files-average*per-changed-file`
+  (e.g. `80*70*60`). Missing fields fall back to `report-thresholds-default`, then to 0.0.
+  Global thresholds are a separate evaluation pass.
+- `baseline-paths` (optional): List of glob patterns for baseline reports for this group.
 
 For the full format reference see [docs/report-groups-format.md](docs/report-groups-format.md).
 
+When multiple groups omit `baseline-paths` while top-level `baseline-paths` is set, inheritance is
+treated as ambiguous and grouped baseline scans are skipped for those omitted groups.
+
 > **YAML quoting note**: Any `paths`, `baseline-paths`, or `thresholds` value that begins with `*` must be quoted,
 > otherwise YAML interprets the leading `*` as a YAML alias.
+>
 > ```yaml
 > paths:
 >   - '**/jacoco.xml'       # leading * — must be quoted
@@ -453,14 +476,16 @@ The `debug` input enables detailed logging. It is automatically enabled when
 
 - Check that your build step runs **before** this action and actually produces the XML files.
 - Use `debug: 'true'` to log every glob expansion result.
-- Verify the `paths` pattern resolves to real files. Both repository-relative patterns and absolute `${{ github.workspace }}` paths are supported.
+- Verify the `paths` pattern resolves to real files.
+  Both repository-relative patterns and absolute `${{ github.workspace }}` paths are supported.
 - If the path contains a leading `*` in a `report-groups` YAML block, wrap it in quotes:
   `- '**/jacoco.xml'`.
 
 ### No PR comment is posted
 
 - Confirm `comment-level` is not set to `none`.
-- Confirm the job token permissions include `issues: write` (comment create/update/delete) and `pull-requests: read` (PR files lookup).
+- Confirm the job token permissions include `issues: write` (comment create/update/delete)
+  and `pull-requests: read` (PR files lookup).
 - If `skip-unchanged: true` and all reports have no changed files:
   - with `evaluate-unchanged: false`, the action exits cleanly with no comment by design;
   - with `evaluate-unchanged: true` (default), unchanged reports are still evaluated for threshold failures.
@@ -468,12 +493,15 @@ The `debug` input enables detailed logging. It is automatically enabled when
 ### The action fails with a threshold error but the comment shows ✅
 
 - Check whether `fail-on-threshold` lists dimensions that differ from the thresholds you set in
-  `global-thresholds`. By default, all three dimensions are enforced.
+  `global-thresholds` and `report-thresholds-default`.
+  By default, `overall`, `changed-files-average`, and `per-changed-file` checks are enabled;
+  the per-changed-file check uses report/group thresholds.
 - When `report-groups` is used, group thresholds are evaluated separately from `global-thresholds`.
 
 ### `fail-on-threshold: true` shows a deprecation warning
 
 - Boolean values for `fail-on-threshold` are deprecated in v3. Replace with the list form:
+
   ```yaml
   fail-on-threshold: 'overall,changed-files-average,per-changed-file'
   ```

--- a/README.md
+++ b/README.md
@@ -2,20 +2,59 @@
 
 ![GitHub tag](https://img.shields.io/github/v/tag/MoranaApps/jacoco-report?label=latest&style=flat-square&color=blue)
 
+- [Motivation](#motivation)
+- [Quick Start](#quick-start)
 - [Usage](#usage)
   - [Action Inputs](#action-inputs)
   - [Outputs](#outputs)
   - [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
 - [Developer](#developer)
 - [License](#license)
 - [Donate](#donate)
 
 Automates the publication of JaCoCo coverage reports directly as comments in pull requests.
 
-Requirements
+**Requirements**
 
 - **GitHub Token**: A GitHub token with permission to fetch repository data such as Issues and Pull Requests.
 - **Python 3.13+**: Ensure you have Python 3.13 installed on your system.
+
+---
+
+## Motivation
+
+Reviewing coverage numbers by hunting through CI logs is tedious. This action posts a structured
+coverage report as a PR comment — directly where the review happens — so the whole team can see
+which files changed, what their coverage is, and whether thresholds are met, without leaving GitHub.
+
+Key capabilities:
+
+- **Global thresholds** — enforce overall, average-changed, and per-file minimums in one input.
+- **Report groups** — organise multi-module projects into named groups with per-group thresholds.
+- **Baseline comparison** — show Δ coverage against a stored baseline (e.g. `main` branch reports).
+- **Flexible comment levels** — from a single-line summary to full per-file detail, or no comment at all.
+- **Skip-unchanged filter** — remove reports with no changed files from the comment (and optionally from evaluation).
+
+---
+
+## Quick Start
+
+Add the following step to any job that already produces a JaCoCo XML report:
+
+```yaml
+- name: Publish JaCoCo Report
+  uses: MoranaApps/jacoco-report@v3
+  with:
+    token: '${{ secrets.GITHUB_TOKEN }}'
+    paths: '**/jacoco.xml'
+    global-thresholds: '80*70*60'   # overall * changed-avg * per-file
+```
+
+This posts a full PR comment and fails the action if any threshold is not met.
+See the [examples/](examples/) directory for more complete workflow files.
+
+---
 
 ## Usage
 
@@ -32,23 +71,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
       - name: Publish JaCoCo Report in PR comments
         uses: MoranaApps/jacoco-report@v3
         with:
-          token: '${{ secrets.TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
           paths: |
-            src/reports/jacoco/jacoco.xml                         # Path to the JaCoCo XML report in the repository
-            **/jacoco.xml                                         # Match all Jacoco XML files in the repository
-            **/reports/**/*.xml                                   # Match all XML files in the reports directory       
-            ${{ github.workspace }}/**/jacoco.xml                 # Match all Jacoco XML files in the workspace
-            ${{ github.workspace }}/**/build/reports/**/*.xml     # Match all XML files in the build/reports directory
-            /home/runner/work/<repo-name>/<repo-name>/jacoco.xml  # Absolute path to the Jacoco XML report
+            src/reports/jacoco/jacoco.xml
+            **/jacoco.xml
+            **/reports/**/*.xml
+            ${{ github.workspace }}/**/jacoco.xml
 ```
 
 ---
@@ -60,23 +97,25 @@ jobs:
 | `token`             | GitHub token for authentication with the repository.                                                                                                                                                                           | **Yes**  |                                                  |
 | `paths`             | Newline-separated paths to JaCoCo XML files. Supports wildcard glob patterns. Required when `report-groups` is not set.                                                                                                        | No       | `''`                                             |
 | `exclude-paths`     | Newline-separated paths to exclude from coverage analysis. Supports glob patterns.                                                                                                                                             | No       | `''`                                             |
-| `global-thresholds` | Global coverage thresholds in `overall*changed-files-average*changed-file` format. Evaluated independently as a separate pass over aggregated totals.                                                                         | No       | `0.0*0.0*0.0`                                    |
+| `global-thresholds` | Global coverage thresholds in `overall*changed-files-average*per-changed-file` format. Evaluated independently as a separate pass over aggregated totals.                                                                      | No       | `0.0*0.0*0.0`                                    |
 | `report-thresholds-default` | Default thresholds for reports/groups when a group omits a threshold field. Format: `overall*changed-files-average*per-changed-file` (e.g. `75*60*0`). Field-level fallback chain: per-group → this default → 0.0.        | No       | `0.0*0.0*0.0`                                    |
 | `title`             | Title for the coverage report comment added to the Pull Request.                                                                                                                                                               | No       | `JaCoCo Coverage Report`                         |
-| `pr-number`         | Number of the pull request. If not provided, the action will attempt to determine <br> the PR number from the GitHub context.                                                                                                  | No       | `''`                                             |
+| `pr-number`         | Number of the pull request. If not provided, the action will attempt to determine the PR number from the GitHub context.                                                                                                       | No       | `''`                                             |
 | `metric`            | Coverage metric to use (`instruction`, `line`, `branch`, `complexity`, `method`, `class`).                                                                                                                                     | No       | `instruction`                                    |
-| `comment-level`     | Comment output level: `none`, `minimal`, `full`, `changed`, `failed`, or `failed-or-changed`. `changed`, `failed`, and `failed-or-changed` keep the global summary table and filter lower tables by row.                     | No       | `full`                                           |
-| `report-groups`     | Named report groups as a YAML list. Each entry: `name` (required), `paths` (required list of globs), `thresholds` (optional `O*A*P`, e.g. `80*70*60`), `baseline-paths` (optional list). When set, group `paths` are used. | No       | `''`                                             |
-| `skip-unchanged`    | If `true`, reports with no changed files are filtered out from comment rows. Whether they still affect action success/failure is controlled by `evaluate-unchanged`.                                                           | No       | `false`                                          |
-| `evaluate-unchanged` | Applies only when `skip-unchanged=true`. If `true`, filtered unchanged reports can still fail overall thresholds (result-only). If `false`, they are excluded from threshold evaluation as well.                               | No       | `true`                                           |
+| `comment-level`     | Comment output level: `none`, `minimal`, `full`, `changed`, `failed`, or `failed-or-changed`. See [docs/comment-level-guide.md](docs/comment-level-guide.md).                                                                 | No       | `full`                                           |
+| `report-groups`     | Named report groups as a YAML list. Each entry: `name` (required), `paths` (required list of globs), `thresholds` (optional `O*A*P`), `baseline-paths` (optional list). See [docs/report-groups-format.md](docs/report-groups-format.md). | No  | `''`                                      |
+| `skip-unchanged`    | If `true`, reports with no changed files are filtered out before evaluation.                                                                                                                                                   | No       | `false`                                          |
+| `evaluate-unchanged` | Applies only when `skip-unchanged=true`. If `true`, filtered reports can still fail overall thresholds. If `false`, they are excluded from threshold evaluation as well.                                                       | No       | `true`                                           |
 | `baseline-paths`    | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.                                                                                                                                            | No       | `''`                                             |
-| `update-comment`    | If `true`, updates an existing comment instead of creating a new one, preventing clutter.                                                                                                                                      | No       | `true`                                           |
+| `update-comment`    | If `true`, updates an existing comment instead of creating a new one.                                                                                                                                                          | No       | `true`                                           |
 | `pass-symbol`       | Symbol for passing checks in PR comments (e.g., ✅, **Passed**).                                                                                                                                                               | No       | `✅`                                              |
 | `fail-symbol`       | Symbol for failing checks in PR comments (e.g., ❌, **Failed**).                                                                                                                                                               | No       | `❌`                                              |
 | `fail-on-threshold` | Comma- or newline-separated list of thresholds that must pass: `overall`, `changed-files-average`, `per-changed-file`. Leave empty to disable.                                                                                | No       | `overall,changed-files-average,per-changed-file` |
 | `debug`             | Enables detailed logging. Automatically activated when `ACTIONS_RUNNER_DEBUG=true`.                                                                                                                                            | No       | `false`                                          |
 
 > Hint: default values have been defined to provide maximal possible information in the comment.
+
+---
 
 #### Outputs
 
@@ -85,14 +124,15 @@ The following outputs are set by the JaCoCo GitHub Action:
 - `coverage-overall`: The overall code coverage percentage.
 - `coverage-changed-files`: The code coverage percentage for the changed files.
 - `coverage-overall-passed`: A boolean indicating if the overall code coverage meets the minimum threshold.
-- `coverage-changed-files-passed`: A boolean indicating if the code coverage for the changed files meets the minimum
-threshold.
+- `coverage-changed-files-passed`: A boolean indicating if the code coverage for the changed files meets the minimum threshold.
 - `reports-coverage`: A JSON string containing the evaluated coverage per report.
 - `groups-coverage`: A JSON string containing the evaluated coverage per report group (populated when `report-groups` is defined).
-  
+
+---
+
 ### Examples
 
-- [Customizing the Exclude Paths](#customizing-paths-and-exclude-paths)
+- [Customizing Paths and Exclude Paths](#customizing-paths-and-exclude-paths)
 - [Customizing the Global Coverage Thresholds](#customizing-the-global-coverage-thresholds)
 - [Customizing the PR Number](#customizing-the-pr-number)
 - [Customizing the Report Title](#customizing-the-report-title)
@@ -114,9 +154,8 @@ threshold.
 The `paths` input allows you to specify the paths to the JaCoCo XML files that should be included in the code coverage
 analysis. This input is required only when `report-groups` is not provided.
 
-- You can use wildcard glob patterns to match multiple files:
-  - `**/*.xml` will match all XML files in the repository.
-- You can specify final list of paths separated by commas.
+- You can use wildcard glob patterns to match multiple files.
+- Multiple paths may be specified as a newline-separated list or comma-separated on one line.
 
 The `exclude-paths` input allows you to specify files or directories that should be excluded from the code coverage
 analysis.
@@ -125,49 +164,44 @@ analysis.
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: |
       module-a/target/jacoco/code-coverage.xml,
       module-b/target/jacoco/code-coverage.xml,
       module-c/target/jacoco/**/*.xml
     exclude-paths: |
-      **/temp/**,                       # Exclude temporary files in all directories
-      **/legacy/**,                     # Exclude legacy files in all directories
-      module-c/target/**/excluded/**    # Exclude specific paths in module-c
+      **/temp/**,
+      **/legacy/**,
+      module-c/target/**/excluded/**
 ```
 
-#### Customizing the Coverage Thresholds
+#### Customizing the Global Coverage Thresholds
 
-The `global-thresholds` input allows you to define global coverage thresholds for the overall, average changed files,
-and each changed file coverage. This input is a string in the format:
-
-- `overall*changed-files-average*changed-file`
-
-Where:
-
-- `overall`: Minimum overall coverage percentage required.
-- `changed-files-average`: Minimum average coverage percentage required for changed files.
-- `changed-file`: Minimum coverage percentage required for each individual changed file.
+The `global-thresholds` input defines coverage thresholds for the aggregated totals in the format
+`overall*changed-files-average*per-changed-file`.
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    global-thresholds: 80*70*60  # Min coverage: 80% overall, 70% changed avg, 60% per file
-
-    fail-on-threshold: true  # Fail the GitHub action if any of the thresholds is not reached
+    global-thresholds: '80*70*60'   # 80% overall, 70% changed avg, 60% per file
+    fail-on-threshold: 'overall,changed-files-average,per-changed-file'
 ```
 
-The user can also specify which thresholds should be used to fail the GitHub action.
+To fail only on the overall threshold:
 
 ```yaml
-    # Fail the GitHub action if overall or changed files average threshold is not reached
-    fail-on-threshold:
-      overall
-      changed-files-average 
- ```
+    global-thresholds: '80*0*0'
+    fail-on-threshold: 'overall'
+```
+
+To disable threshold-based failure entirely:
+
+```yaml
+    fail-on-threshold: ''
+```
 
 #### Customizing the PR Number
 
@@ -178,20 +212,20 @@ to determine the PR number from the GitHub context.
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    pr-number: ${{ github.event.pull_request.number }}
- ```
+    pr-number: '${{ github.event.pull_request.number }}'
+```
 
 #### Customizing the Report Title
 
-The `title` input lets you specify a `custom title` for the JaCoCo coverage report comment.
+The `title` input lets you specify a custom title for the JaCoCo coverage report comment.
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
     title: 'Custom Coverage Report Title'
 ```
@@ -207,200 +241,248 @@ Each entry is a YAML mapping with:
 - `thresholds` (optional): `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Missing fields fall back to `report-thresholds-default`, then to 0.0. Global thresholds are a separate evaluation pass.
 - `baseline-paths` (optional): List of glob patterns for baseline reports for this group. Falls back to `baseline-paths`.
 
-> **YAML quoting note**: Any `paths`, `baseline-paths`, or `thresholds` value that begins with `*` (e.g. `**/jacoco.xml` or `*70*60`) must be quoted, otherwise YAML interprets the leading `*` as an alias and raises an "undefined alias" error.
+For the full format reference see [docs/report-groups-format.md](docs/report-groups-format.md).
+
+> **YAML quoting note**: Any `paths`, `baseline-paths`, or `thresholds` value that begins with `*` must be quoted,
+> otherwise YAML interprets the leading `*` as an alias.
 > ```yaml
 > paths:
->   - '**/jacoco.xml'     # quoted — safe
+>   - '**/jacoco.xml'       # leading * — must be quoted
 >   - module/**/jacoco.xml  # no leading * — safe without quotes
-> thresholds: '80*70*60'    # quoted — safe
+> thresholds: '80*70*60'    # always quote thresholds
 > ```
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
+    report-thresholds-default: '75*60*0'
     report-groups: |
       - name: Core
         paths:
           - core/target/site/jacoco/jacoco.xml
-        thresholds: 80*70*60
+        thresholds: '80*70*60'
       - name: Modules
         paths:
           - module-a/target/site/jacoco/jacoco.xml
           - module-b/target/site/jacoco/jacoco.xml
-        thresholds: 75*65*
+        thresholds: '75*65*'
         baseline-paths:
           - baseline/modules/**/*.xml
 ```
 
 #### Customizing the Comment Level
 
+The `comment-level` input controls how much detail appears in the PR comment.
+See [docs/comment-level-guide.md](docs/comment-level-guide.md) for a full description of each level.
+
 ##### No Comment
 
-- When the `comment-level` is set to `none`, no PR comment is posted.
-- If `update-comment: true` and a previous JaCoCo comment with the same title exists, that stale comment is deleted.
+When `comment-level` is set to `none`, no PR comment is posted (threshold evaluation still runs).
+
+```yaml
+    comment-level: 'none'
+```
 
 ##### Minimal Level
 
-- When the `comment-level` is set to `minimal`, one comment is added to the pull request representing the overall and
-changed files coverage for all detected report files.
+When `comment-level` is set to `minimal`, a single global summary table is posted.
 
 ###### JaCoCo Coverage Report
 
 | Metric (Instruction) | Coverage | Threshold | Δ Coverage | Status |
 |----------------------|----------|-----------|------------|--------|
-| **Overall**          | 85.2%    | 80%       | +1.3%      | ✅      |
-| **Changed Files**    | 78.4%    | 80%       | -0.3%      | ❌      |
+| **Overall**          | 85.2%    | 80.0%     | +1.3%      | ✅     |
+| **Changed Files**    | 78.4%    | 80.0%     | -0.3%      | ❌     |
 
-> Δ Coverage is visible when `baseline-paths` defined and data is available.
+> Δ Coverage is visible when `baseline-paths` is defined and data is available.
+
+```yaml
+    comment-level: 'minimal'
+```
 
 ##### Full Level
 
-- When the `comment-level` is set to `full`, one comment is added to the pull request representing the overall and
-changed files coverage for all detected report files.
+When `comment-level` is set to `full`, all tables are shown: global summary, groups (if configured),
+per-report, and per-changed-file.
 
 ###### JaCoCo Coverage Report
 
 | Metric (Instruction) | Coverage | Threshold | Δ Coverage | Status |
 |----------------------|----------|-----------|------------|--------|
-| **Overall**          | 85.2%    | 80%       | +1,3%      | ✅      |
-| **Changed Files**    | 78.4%    | 80%       | 0.3%       | ❌      |
+| **Overall**          | 85.2%    | 80.0%     | +1.3%      | ✅     |
+| **Changed Files**    | 78.4%    | 80.0%     | -0.3%      | ❌     |
 
 | Report          | Coverage (O/Ch) | Threshold (O/Ch) | Δ Coverage (O/Ch) | Status (O/Ch) |
 |-----------------|-----------------|------------------|-------------------|---------------|
-| `Report 1 name` | 87.5% / 35.2%   | 60% / 80%        | -0.6% / +1.0%     | ✅/✅           |
-| `Report 2 name` | 80.0% / 45.6%   | 40% / 82%        | +0.3% / -2.1%     | ✅/✅           |
-| `Report 3 name` | 76.3% / 76.4%   | 50% / 76%        | -2.5% / -1.2%     | ❌/✅           |
+| `Report 1 name` | 87.5% / 35.2%   | 60.0% / 80.0%    | -0.6% / +1.0%     | ✅/✅          |
+| `Report 2 name` | 80.0% / 45.6%   | 40.0% / 82.0%    | +0.3% / -2.1%     | ✅/✅          |
+| `Report 3 name` | 76.3% / 76.4%   | 50.0% / 76.0%    | -2.5% / -1.2%     | ❌/✅          |
 
-| File Path              | Coverage | Threshold | Δ Coverage | Status |
-|------------------------|----------|-----------|------------|--------|
-| `File1.java`           | 90.1%    | 80%       | +0.3%      | ✅      |
-| `File2.java`           | 70.5%    | 80%       | -1.0%      | ❌      |
-| `File3.java`           | 82.1%    | 80%       | +2.7%      | ✅      |
+| File Path    | Coverage | Threshold | Δ Coverage | Status |
+|--------------|----------|-----------|------------|--------|
+| `File1.java` | 90.1%    | 80.0%     | +0.3%      | ✅     |
+| `File2.java` | 70.5%    | 80.0%     | -1.0%      | ❌     |
+| `File3.java` | 82.1%    | 80.0%     | +2.7%      | ✅     |
 
-> - **(O)** - Overall coverage.
-> - **(Ch)** - Coverage for changed files.
-> - **Δ Coverage** is visible when `baseline-paths` are defined and data is available.
-> - The report table is always visible. When `report-groups` is defined, each group's thresholds are used (with field-level fallback to `report-thresholds-default`); otherwise, reports use `report-thresholds-default` (per-field fallback to 0.0).
-> - The groups table is visible when `report-groups` is defined.
-> - `global-thresholds` is always evaluated independently as a separate pass over aggregated totals and is never part of the group fallback chain.
+> - **(O)** — Overall coverage.
+> - **(Ch)** — Coverage for changed files.
+> - **Δ Coverage** is visible when `baseline-paths` is defined and data is available.
+> - The groups table is visible only when `report-groups` is configured.
+> - `global-thresholds` is always evaluated as a separate pass over aggregated totals.
+
+```yaml
+    comment-level: 'full'
+```
 
 ##### Changed Level
 
-- When the `comment-level` is set to `changed`, the global summary table is kept and only group, report, and file rows with changed files are shown.
+When `comment-level` is set to `changed`, all tables are shown but rows where **changed files = 0**
+are hidden in the groups, reports, and changed-files tables.
+
+```yaml
+    comment-level: 'changed'
+```
 
 ##### Failed Level
 
-- When the `comment-level` is set to `failed`, the global summary table is kept and only rows failing their threshold are shown.
+When `comment-level` is set to `failed`, all tables are shown but only rows that **fail** their
+threshold are visible in the groups, reports, and changed-files tables.
+
+```yaml
+    comment-level: 'failed'
+```
 
 ##### Failed-or-Changed Level
 
-- When the `comment-level` is set to `failed-or-changed`, the global summary table is kept and rows are shown when they either have changed files or fail a threshold.
+When `comment-level` is set to `failed-or-changed`, rows are shown when they either have changed
+files **or** fail a threshold — the union of `changed` and `failed`.
+
+```yaml
+    comment-level: 'failed-or-changed'
+```
 
 #### Customizing the Skip Unchanged Option and Update Comment
 
-`skip-unchanged` and `evaluate-unchanged` are related:
+`skip-unchanged` and `evaluate-unchanged` work together:
 
 | `skip-unchanged` | `evaluate-unchanged` | Comment rows for unchanged reports | Can unchanged reports fail the action? |
-|---|---|---|---|
-| `false` | `true` or `false` | Shown (normal flow) | Yes (normal evaluation flow) |
-| `true` | `false` | Hidden | No |
-| `true` | `true` | Hidden | Yes (overall threshold only; result-only check) |
-
-Use this when you want a clean comment but still enforce unchanged-module quality in the action result.
-
-The `update-comment` input, when set to true, updates an existing comment with the latest coverage data instead of
-creating a new comment.
-The comment is identified by the title.
+|------------------|----------------------|------------------------------------|----------------------------------------|
+| `false`          | any                  | Shown (normal flow)                | Yes (normal evaluation)                |
+| `true`           | `false`              | Hidden                             | No                                     |
+| `true`           | `true`               | Hidden                             | Yes (overall threshold only)           |
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    skip-unchanged: true  # Skip commenting for unchanged files
-    update-comment: true  # Update the existing comment with the latest coverage data
+    skip-unchanged: 'true'
+    update-comment: 'true'
 ```
 
-Example: hide unchanged reports and also ignore them for pass/fail
+Hide unchanged reports and exclude them from pass/fail evaluation:
 
 ```yaml
-- name: Publish JaCoCo Report
-  uses: MoranaApps/jacoco-report@v3
-  with:
-    token: '${{ secrets.TOKEN }}'
-    paths: '**/jacoco/**/*.xml'
-    skip-unchanged: true
-    evaluate-unchanged: false
+    skip-unchanged: 'true'
+    evaluate-unchanged: 'false'
 ```
 
-Example: hide unchanged reports but still enforce unchanged overall thresholds
+Hide unchanged reports but still enforce their overall threshold:
 
 ```yaml
-- name: Publish JaCoCo Report
-  uses: MoranaApps/jacoco-report@v3
-  with:
-    token: '${{ secrets.TOKEN }}'
-    paths: '**/jacoco/**/*.xml'
-    report-thresholds-default: 80*70*0
-    skip-unchanged: true
-    evaluate-unchanged: true
+    report-thresholds-default: '80*0*0'
+    skip-unchanged: 'true'
+    evaluate-unchanged: 'true'
 ```
 
 #### Customizing the Baseline Paths
 
-The `baseline-paths` input allows you to define paths to baseline coverage reports. This enables comparing the pull
-request coverage with an established baseline, such as the main branch.
+The `baseline-paths` input defines paths to baseline coverage reports, enabling Δ coverage
+comparison against an established reference (e.g. the `main` branch).
 
-**Required**: Each report has defined unique report name (report title). The report name is used to match the baseline
-report with the current report.
+**Required**: each report must have a unique title that matches the corresponding baseline report.
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
-    paths: |
-      **/jacoco/**/*.xml
-    baseline-paths: |
-      baseline/master/jacoco/**/*.xml              # Match all baseline reports in master directory for jacoco 
+    token: '${{ secrets.GITHUB_TOKEN }}'
+    paths: '**/jacoco/**/*.xml'
+    baseline-paths: 'baseline/master/jacoco/**/*.xml'
 ```
 
 #### Customizing the Symbols and Metric Type
 
-The `pass-symbol` and `fail-symbol` inputs allow you to define custom symbols for passing and failing checks in the
-pull request comments.
-
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    metric: 'LINE'            # Select 'line' coverage metric
-    pass-symbol: '✔️'         # Custom symbol for passing checks
-    fail-symbol: '❗'         # Custom symbol for failing checks
+    metric: 'line'         # instruction | line | branch | complexity | method | class
+    pass-symbol: '✔️'
+    fail-symbol: '❗'
 ```
 
 #### Customizing the Debug Mode
 
-The `debug` input enables detailed logging for debugging. This is automatically enabled in debug mode
-(`ACTIONS_RUNNER_DEBUG=true`).
+The `debug` input enables detailed logging. It is automatically enabled when
+`ACTIONS_RUNNER_DEBUG=true` is set in the repository secrets.
 
 ```yaml
 - name: Publish JaCoCo Report
   uses: MoranaApps/jacoco-report@v3
   with:
-    token: '${{ secrets.TOKEN }}'
+    token: '${{ secrets.GITHUB_TOKEN }}'
     paths: '**/jacoco/**/*.xml'
-    debug: true  # Enable detailed logging
+    debug: 'true'
 ```
+
+---
+
+## Troubleshooting
+
+### The action cannot find any JaCoCo XML files
+
+- Check that your build step runs **before** this action and actually produces the XML files.
+- Use `debug: 'true'` to log every glob expansion result.
+- Verify the `paths` pattern is relative to the repository root (not the workspace).
+- If the path contains a leading `*` in a `report-groups` YAML block, wrap it in quotes:
+  `- '**/jacoco.xml'`.
+
+### No PR comment is posted
+
+- Confirm `comment-level` is not set to `none`.
+- Confirm the `token` has write permission to pull requests (`pull-requests: write`).
+- If `skip-unchanged: true` and all reports have no changed files, the action exits cleanly
+  with no comment by design.
+
+### The action fails with a threshold error but the comment shows ✅
+
+- Check whether `fail-on-threshold` lists dimensions that differ from the thresholds you set in
+  `global-thresholds`. By default, all three dimensions are enforced.
+- When `report-groups` is used, group thresholds are evaluated separately from `global-thresholds`.
+
+### `fail-on-threshold: true` shows a deprecation warning
+
+- Boolean values for `fail-on-threshold` are deprecated in v3. Replace with the list form:
+  ```yaml
+  fail-on-threshold: 'overall,changed-files-average,per-changed-file'
+  ```
+
+### Migrating from v2
+
+See [docs/v2-v3-migration-guide.md](docs/v2-v3-migration-guide.md) for a full before/after guide
+covering every breaking change.
+
+---
 
 ## Developer
 
-Follow the [DEVELOPER.md](DEVELOPER.md) guide to setup the development environment.
+Follow the [DEVELOPER.md](DEVELOPER.md) guide to set up the development environment.
 
 ## License
 
@@ -410,8 +492,8 @@ Follow the [DEVELOPER.md](DEVELOPER.md) guide to setup the development environme
 
 If you find this project useful or interesting, consider supporting it!
 
-Your donation helps me keep building, maintaining and improving this tool — every bit of support matters and is deeply
-appreciated.
+Your donation helps me keep building, maintaining and improving this tool — every bit of support
+matters and is deeply appreciated.
 
 - [Buy me a coffee on Ko-fi](https://ko-fi.com/mirpo)
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ jobs:
 | `pass-symbol`       | Symbol for passing checks in PR comments (e.g., ✅, **Passed**).                                                                                                                                                               | No       | `✅`                                              |
 | `fail-symbol`       | Symbol for failing checks in PR comments (e.g., ❌, **Failed**).                                                                                                                                                               | No       | `❌`                                              |
 | `fail-on-threshold` | Comma- or newline-separated list of thresholds that must pass: `overall`, `changed-files-average`, `per-changed-file`. Leave empty to disable.                                                                                | No       | `overall,changed-files-average,per-changed-file` |
-| `debug`             | Enables detailed logging. Automatically activated when `ACTIONS_RUNNER_DEBUG=true`.                                                                                                                                            | No       | `false`                                          |
+| `debug`             | Enables detailed logging. Automatically activated when `RUNNER_DEBUG=1` (GitHub runner debug mode).                                                                                                                             | No       | `false`                                          |
 
 > Hint: default values have been defined to provide maximal possible information in the comment.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Automates the publication of JaCoCo coverage reports directly as comments in pull requests.
 
-**Requirements**
+## Requirements
 
 - **GitHub Token**: A GitHub token with permission to fetch repository data such as Issues and Pull Requests.
 - **Python 3.13+**: Ensure you have Python 3.13 installed on your system.
@@ -69,6 +69,10 @@ on:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -155,7 +159,7 @@ The `paths` input allows you to specify the paths to the JaCoCo XML files that s
 analysis. This input is required only when `report-groups` is not provided.
 
 - You can use wildcard glob patterns to match multiple files.
-- Multiple paths may be specified as a newline-separated list or comma-separated on one line.
+- Multiple paths must be specified as a newline-separated list.
 
 The `exclude-paths` input allows you to specify files or directories that should be excluded from the code coverage
 analysis.
@@ -166,12 +170,12 @@ analysis.
   with:
     token: '${{ secrets.GITHUB_TOKEN }}'
     paths: |
-      module-a/target/jacoco/code-coverage.xml,
-      module-b/target/jacoco/code-coverage.xml,
+      module-a/target/jacoco/code-coverage.xml
+      module-b/target/jacoco/code-coverage.xml
       module-c/target/jacoco/**/*.xml
     exclude-paths: |
-      **/temp/**,
-      **/legacy/**,
+      **/temp/**
+      **/legacy/**
       module-c/target/**/excluded/**
 ```
 
@@ -239,12 +243,12 @@ Each entry is a YAML mapping with:
 - `name` (required): Group name shown in the PR comment groups table.
 - `paths` (required): List of glob patterns for JaCoCo XML reports in this group.
 - `thresholds` (optional): `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Missing fields fall back to `report-thresholds-default`, then to 0.0. Global thresholds are a separate evaluation pass.
-- `baseline-paths` (optional): List of glob patterns for baseline reports for this group. Falls back to `baseline-paths`.
+- `baseline-paths` (optional): List of glob patterns for baseline reports for this group. Falls back to top-level `baseline-paths` only when exactly one group omits `baseline-paths`; when multiple groups omit it, baseline inheritance is treated as ambiguous and skipped for those groups.
 
 For the full format reference see [docs/report-groups-format.md](docs/report-groups-format.md).
 
 > **YAML quoting note**: Any `paths`, `baseline-paths`, or `thresholds` value that begins with `*` must be quoted,
-> otherwise YAML interprets the leading `*` as an alias.
+> otherwise YAML interprets the leading `*` as a YAML alias.
 > ```yaml
 > paths:
 >   - '**/jacoco.xml'       # leading * — must be quoted
@@ -449,16 +453,17 @@ The `debug` input enables detailed logging. It is automatically enabled when
 
 - Check that your build step runs **before** this action and actually produces the XML files.
 - Use `debug: 'true'` to log every glob expansion result.
-- Verify the `paths` pattern is relative to the repository root (not the workspace).
+- Verify the `paths` pattern resolves to real files. Both repository-relative patterns and absolute `${{ github.workspace }}` paths are supported.
 - If the path contains a leading `*` in a `report-groups` YAML block, wrap it in quotes:
   `- '**/jacoco.xml'`.
 
 ### No PR comment is posted
 
 - Confirm `comment-level` is not set to `none`.
-- Confirm the `token` has write permission to pull requests (`pull-requests: write`).
-- If `skip-unchanged: true` and all reports have no changed files, the action exits cleanly
-  with no comment by design.
+- Confirm the job token permissions include `issues: write` (comment create/update/delete) and `pull-requests: read` (PR files lookup).
+- If `skip-unchanged: true` and all reports have no changed files:
+  - with `evaluate-unchanged: false`, the action exits cleanly with no comment by design;
+  - with `evaluate-unchanged: true` (default), unchanged reports are still evaluated for threshold failures.
 
 ### The action fails with a threshold error but the comment shows ✅
 
@@ -497,4 +502,4 @@ matters and is deeply appreciated.
 
 - [Buy me a coffee on Ko-fi](https://ko-fi.com/mirpo)
 
-**Thanks for keeping this project alive!**
+Thanks for keeping this project alive.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![GitHub tag](https://img.shields.io/github/v/tag/MoranaApps/jacoco-report?label=latest&style=flat-square&color=blue)
 
-- [Motivation](#motivation)
 - [Requirements](#requirements)
+- [Motivation](#motivation)
 - [Quick Start](#quick-start)
 - [Usage](#usage)
   - [Action Inputs](#action-inputs)
@@ -41,21 +41,24 @@ Key capabilities:
 
 ## Quick Start
 
-Add the following step to any job that already produces a JaCoCo XML report:
+Add the following job fragment to a workflow that already produces a JaCoCo XML report:
 
 ```yaml
-permissions:
-  contents: read
-  issues: write
-  pull-requests: read
-
-- name: Publish JaCoCo Report
-  uses: MoranaApps/jacoco-report@v3
-  with:
-    token: '${{ secrets.GITHUB_TOKEN }}'
-    paths: '**/jacoco.xml'
-    global-thresholds: '80*70*0'        # overall * changed-avg * reserved-third
-    report-thresholds-default: '0*0*60' # per-changed-file threshold
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Publish JaCoCo Report
+        uses: MoranaApps/jacoco-report@v3
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          paths: '**/jacoco.xml'
+          global-thresholds: '80*70*0'        # overall * changed-avg * reserved-third
+          report-thresholds-default: '0*0*60' # per-changed-file threshold
 ```
 
 This posts a full PR comment and fails the action if any threshold is not met.
@@ -115,7 +118,7 @@ jobs:
 | `metric`            | Coverage metric to use (`instruction`, `line`, `branch`, `complexity`, `method`, `class`).                                                                                                                                     | No       | `instruction`                                    |
 | `comment-level`     | Comment output level: `none`, `minimal`, `full`, `changed`, `failed`, or `failed-or-changed`. See [docs/comment-level-guide.md](docs/comment-level-guide.md).                                                                 | No       | `full`                                           |
 | `report-groups`     | Named report groups as a YAML list. Each entry: `name` (required), `paths` (required list of globs), `thresholds` (optional `O*A*P`), `baseline-paths` (optional list). See [docs/report-groups-format.md](docs/report-groups-format.md). | No  | `''`                                      |
-| `skip-unchanged`    | If `true`, reports with no changed files are filtered out before evaluation.                                                                                                                                                   | No       | `false`                                          |
+| `skip-unchanged`    | If `true`, reports with no changed files are filtered out from comment rows. With default `evaluate-unchanged=true`, filtered reports can still affect threshold results.                                                        | No       | `false`                                          |
 | `evaluate-unchanged` | Applies only when `skip-unchanged=true`. If `true`, filtered reports can still fail overall thresholds. If `false`, they are excluded from threshold evaluation as well.                                                       | No       | `true`                                           |
 | `baseline-paths`    | Paths to baseline coverage reports for comparison. Supports wildcard glob patterns.                                                                                                                                            | No       | `''`                                             |
 | `update-comment`    | If `true`, updates an existing comment instead of creating a new one.                                                                                                                                                          | No       | `true`                                           |
@@ -475,7 +478,7 @@ The `debug` input enables detailed logging. It is automatically enabled when
 ### The action cannot find any JaCoCo XML files
 
 - Check that your build step runs **before** this action and actually produces the XML files.
-- Use `debug: 'true'` to log every glob expansion result.
+- Use `debug: 'true'` to log matched JaCoCo XML files discovered by scanning.
 - Verify the `paths` pattern resolves to real files.
   Both repository-relative patterns and absolute `${{ github.workspace }}` paths are supported.
 - If the path contains a leading `*` in a `report-groups` YAML block, wrap it in quotes:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ jobs:
       issues: write
       pull-requests: read
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Publish JaCoCo Report
         uses: MoranaApps/jacoco-report@v3
         with:
@@ -460,7 +465,8 @@ comparison against an established reference (e.g. the `main` branch).
 #### Customizing the Debug Mode
 
 The `debug` input enables detailed logging. It is automatically enabled when
-`ACTIONS_RUNNER_DEBUG=true` is set in the repository secrets.
+`RUNNER_DEBUG=1` is set by GitHub Actions runner debug mode.
+Use `debug: 'true'` to enable debug logs explicitly regardless of runner settings.
 
 ```yaml
 - name: Publish JaCoCo Report

--- a/TASKS.md
+++ b/TASKS.md
@@ -494,7 +494,7 @@ Append to PR comments: run ID, timestamp, trigger event, action version.
 
 Task 38 is gated on tasks 27–30 being complete. Tasks 39–43 may proceed in parallel after task 38.
 
-#### Task 38 — v2→v3 migration guide ⬜
+#### Task 38 — v2→v3 migration guide ✅
 
 **Branch:** `docs/74-v2-v3-migration-guide` | **Issue:** #74
 **Depends on:** Tasks 27, 28, 29, 30 (all core features done)
@@ -536,7 +536,8 @@ Task 38 is gated on tasks 27–30 being complete. Tasks 39–43 may proceed in p
 #### Task 42 — Document `report-groups` YAML format ✅
 
 **Branch:** `docs/improve-docs` | **Issue:** #98
-- Created `docs/report-groups-format.md` with full schema, field reference, threshold resolution, quoting rules, and examples
+- Created `docs/report-groups-format.md` with full schema, field reference,
+  threshold resolution, quoting rules, and examples
 - README `report-groups` section links to the new doc
 
 #### Task 43 — Create `examples/` directory ✅

--- a/TASKS.md
+++ b/TASKS.md
@@ -78,11 +78,11 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **36** | I | Enhanced logging (thresholds + reached values) | ✅ | `feature/101-enhance-threshold-logging` | #101 |
 | **37** | I | PR comment metadata | ✅ | `feature/94-pr-comment-metadata` | #94 |
 | **38** | J | v2→v3 migration guide | ✅ | `docs/74-v2-v3-migration-guide` | #74 |
-| **39** | J | Create `docs/` directory | 🔒 ⬜ | `docs/extended-docs-directory` | new |
-| **40** | J | Update `DEVELOPER.md` | 🔒 ⬜ | `docs/update-developer-md` | new |
-| **41** | J | Update `README.md` | 🔒 ⬜ | `feature/70-Improve-README` | #70 |
-| **42** | J | Document `report-groups` YAML format | 🔒 ⬜ | `docs/98-report-groups-format-docs` | #98 |
-| **43** | J | Create `examples/` directory | 🔒 ⬜ | `docs/examples-directory` | new |
+| **39** | J | Create `docs/` directory | ✅ | `docs/improve-docs` | new |
+| **40** | J | Update `DEVELOPER.md` | ✅ | `docs/improve-docs` | new |
+| **41** | J | Update `README.md` | ✅ | `docs/improve-docs` | #70 |
+| **42** | J | Document `report-groups` YAML format | ✅ | `docs/improve-docs` | #98 |
+| **43** | J | Create `examples/` directory | ✅ | `docs/improve-docs` | new |
 | **44** | K | Remove `# pylint: disable` inline suppressions | 🔒 ⬜ | `fix/95-remove-pylint-inline-disables` | #95 |
 | **45** | K | `WRITE_SNAPSHOTS` regeneration guard | 🔒 ⬜ | `chore/snapshot-write-guard` | new |
 | **46** | L | Introduce Pydantic for validation | ⬜ | `feature/39-pydantic-input-validation` | #39 |
@@ -508,41 +508,43 @@ Task 38 is gated on tasks 27–30 being complete. Tasks 39–43 may proceed in p
 6. `fail-on-threshold: true/false` → deprecated; use list form
 7. `comment-level` → new values: `none`, `changed`, `failed`, `failed-or-changed`
 
-#### Task 39 — Create `docs/` directory ⬜
+#### Task 39 — Create `docs/` directory ✅
 
-**Branch:** `docs/extended-docs-directory` | **Issue:** new
-- Move migration guide here
-- Add `report-groups` YAML format reference
-- Add `comment-level` mode diagrams
+**Branch:** `docs/improve-docs` | **Issue:** new
+- `docs/comment-level-guide.md` — level descriptions with visual table examples
+- `docs/report-groups-format.md` — full YAML schema and field reference
+- `docs/v2-v3-migration-guide.md` — already existed (task 38)
 
-#### Task 40 — Update `DEVELOPER.md` ⬜
+#### Task 40 — Update `DEVELOPER.md` ✅
 
-**Branch:** `docs/update-developer-md` | **Issue:** new
+**Branch:** `docs/improve-docs` | **Issue:** new
+- Branch naming convention table
+- v3-accurate local script examples (removed `modules`/`modules-thresholds`)
 - Integration test section (offline + live)
-- Branch naming convention
 - `WRITE_SNAPSHOTS=1` snapshot regeneration step
-- Updated `mypy` and `pylint` commands
+- `mypy .` command and full QA gate
 
-#### Task 41 — Update `README.md` ⬜
+#### Task 41 — Update `README.md` ✅
 
-**Branch:** `feature/70-Improve-README` *(exists)* | **Issue:** #70
-- Close open branch `feature/70-Improve-README`
-- Add Motivation section, Troubleshooting section
-- Move Quick Start earlier
-- Align all input examples to v3
+**Branch:** `docs/improve-docs` | **Issue:** #70
+- Added Motivation section
+- Added Quick Start section (before Usage)
+- Added Troubleshooting section
+- All examples aligned to v3 inputs
+- Comment-level and report-groups sections link to `docs/`
 
-#### Task 42 — Document `report-groups` YAML format ⬜
+#### Task 42 — Document `report-groups` YAML format ✅
 
-**Branch:** `docs/98-report-groups-format-docs` | **Issue:** #98
-- Replaces the `modules-thresholds` format issue
-- Add to README and `docs/`
+**Branch:** `docs/improve-docs` | **Issue:** #98
+- Created `docs/report-groups-format.md` with full schema, field reference, threshold resolution, quoting rules, and examples
+- README `report-groups` section links to the new doc
 
-#### Task 43 — Create `examples/` directory ⬜
+#### Task 43 — Create `examples/` directory ✅
 
-**Branch:** `docs/examples-directory` | **Issue:** new
-- `basic.yml` — minimal config with `global-thresholds`
-- `report-groups.yml` — multi-group YAML with per-group thresholds
-- `migration-v2-to-v3.yml` — before/after side-by-side
+**Branch:** `docs/improve-docs` | **Issue:** new
+- `examples/basic.yml` — minimal config with `global-thresholds`
+- `examples/report-groups.yml` — multi-group YAML with per-group thresholds and baseline
+- `examples/migration-v2-to-v3.yml` — annotated before/after side-by-side
 
 ---
 
@@ -622,6 +624,6 @@ Task 27 ──────────────────► Task 31
 - [ ] Task 30 (full `comment-level`) done
 - [ ] Task 31 (`fail-on-threshold` deprecation + `evaluate-unchanged`) done
 - [ ] Tasks 32–35 (integration test infrastructure) done
-- [ ] Task 38 (migration guide) done
-- [ ] Tasks 39–43 (documentation) done
+- [x] Task 38 (migration guide) done
+- [x] Tasks 39–43 (documentation) done
 - [ ] QA gate passes on `main`: `pytest --cov=. tests/ --cov-fail-under=80 && pylint $(git ls-files '*.py') && black --check $(git ls-files '*.py') && mypy .`

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Newline-separated paths or globs to exclude from scanning.'
     required: false
   global-thresholds:
-    description: 'Global thresholds in format overall*changed-files-average*changed-file (for aggregated totals).'
+    description: 'Global thresholds in format overall*changed-files-average*reserved-third (aggregated totals use overall and changed-files-average).'
     required: false
     default: '0*0*0'
   report-thresholds-default:

--- a/docs/comment-level-guide.md
+++ b/docs/comment-level-guide.md
@@ -39,7 +39,7 @@ comment-level: 'none'
 
 A single global summary table is posted. Individual report and file rows are not shown.
 
-```
+```text
 | Metric (Instruction) | Coverage | Threshold | Status |
 |----------------------|----------|-----------|--------|
 | **Overall**          | 85.2%    | 80.0%     | ✅     |
@@ -59,7 +59,7 @@ comment-level: 'minimal'
 All tables are posted: global summary, groups (if configured), per-report, and per-changed-file.
 This is the default.
 
-```
+```text
 | Metric (Instruction) | Coverage | Threshold | Status |
 |…|
 
@@ -122,13 +122,13 @@ comment-level: 'failed-or-changed'
 ## Interaction with `skip-unchanged`
 
 `skip-unchanged: true` runs **before** `comment-level` filtering. Reports with no changed files
-are removed from evaluation entirely, so they will not appear in any table regardless of the
-`comment-level` chosen.
+are removed from comment rows. With `evaluate-unchanged: true` (default), those filtered reports
+can still fail overall thresholds even though they do not appear in tables.
 
 | `skip-unchanged` | `comment-level` | Effect |
 |---|---|---|
 | `false` | `changed` | Hide zero-changed rows in comment; still evaluated |
-| `true` | `full` | Changed reports removed before comment is built |
+| `true` | `full` | Unchanged reports removed from comment rows before comment is built |
 | `true` | `changed` | Equivalent to `true` / `full` for unchanged reports; remaining rows with changes shown |
 
 ---
@@ -136,7 +136,8 @@ are removed from evaluation entirely, so they will not appear in any table regar
 ## Interaction with `baseline-paths`
 
 When `baseline-paths` is configured, a **Δ Coverage** column appears in all tables.
-The column is omitted when no baseline data is available for a given row.
+The column is omitted only when no baseline evaluator data exists at all. Rows without a matching
+baseline entry render a `0.0%` delta.
 
 ---
 

--- a/docs/comment-level-guide.md
+++ b/docs/comment-level-guide.md
@@ -1,0 +1,146 @@
+# `comment-level` Guide
+
+The `comment-level` input controls how much information appears in the PR comment posted by the action.
+All levels still run coverage evaluation and honour `fail-on-threshold`; only the comment content differs.
+
+---
+
+## Overview
+
+| Level | Global table | Groups table | Reports table | Changed-files table | Filter applied |
+|-------|:---:|:---:|:---:|:---:|----------------|
+| `none` | — | — | — | — | No comment posted |
+| `minimal` | ✅ | — | — | — | None |
+| `full` | ✅ | ✅* | ✅ | ✅ | None |
+| `changed` | ✅ | ✅* | ✅ | ✅ | Hide rows with zero changed files |
+| `failed` | ✅ | ✅* | ✅ | ✅ | Hide rows that pass their threshold |
+| `failed-or-changed` | ✅ | ✅* | ✅ | ✅ | Show rows that have changes **or** fail |
+
+\* Groups table is included only when `report-groups` is configured.
+
+---
+
+## Level descriptions
+
+### `none`
+
+No PR comment is posted. If `update-comment: true` and a previous JaCoCo comment with the same title
+exists, that stale comment is deleted so the PR stays clean.
+
+Use this when you need threshold enforcement in CI but do not want any comment noise.
+
+```yaml
+comment-level: 'none'
+```
+
+---
+
+### `minimal`
+
+A single global summary table is posted. Individual report and file rows are not shown.
+
+```
+| Metric (Instruction) | Coverage | Threshold | Status |
+|----------------------|----------|-----------|--------|
+| **Overall**          | 85.2%    | 80.0%     | ✅     |
+| **Changed Files**    | 78.4%    | 80.0%     | ❌     |
+```
+
+Use this when you only care about the aggregate pass/fail signal.
+
+```yaml
+comment-level: 'minimal'
+```
+
+---
+
+### `full`
+
+All tables are posted: global summary, groups (if configured), per-report, and per-changed-file.
+This is the default.
+
+```
+| Metric (Instruction) | Coverage | Threshold | Status |
+|…|
+
+| Group    | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|…|
+
+| Report   | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|…|
+
+| File Path | Coverage | Threshold | Status |
+|…|
+```
+
+```yaml
+comment-level: 'full'
+```
+
+---
+
+### `changed`
+
+Same structure as `full`, but rows in the Groups, Reports, and Changed-files tables where
+**changed files = 0** are hidden. The global summary table is always shown in full.
+
+Use this to reduce comment noise in large repos where most modules are untouched in a given PR.
+
+```yaml
+comment-level: 'changed'
+```
+
+---
+
+### `failed`
+
+Same structure as `full`, but only rows that **fail** their threshold are shown in the Groups,
+Reports, and Changed-files tables. The global summary table is always shown in full.
+
+Use this in high-coverage projects where you only want the PR comment to highlight regressions.
+
+```yaml
+comment-level: 'failed'
+```
+
+---
+
+### `failed-or-changed`
+
+Union of `changed` and `failed`: a row is shown when it either has changed files **or** fails its
+threshold. The global summary table is always shown in full.
+
+This is the recommended level for most teams — you get full visibility into active work and any
+regressions, without noise from stable, untouched modules.
+
+```yaml
+comment-level: 'failed-or-changed'
+```
+
+---
+
+## Interaction with `skip-unchanged`
+
+`skip-unchanged: true` runs **before** `comment-level` filtering. Reports with no changed files
+are removed from evaluation entirely, so they will not appear in any table regardless of the
+`comment-level` chosen.
+
+| `skip-unchanged` | `comment-level` | Effect |
+|---|---|---|
+| `false` | `changed` | Hide zero-changed rows in comment; still evaluated |
+| `true` | `full` | Changed reports removed before comment is built |
+| `true` | `changed` | Equivalent to `true` / `full` for unchanged reports; remaining rows with changes shown |
+
+---
+
+## Interaction with `baseline-paths`
+
+When `baseline-paths` is configured, a **Δ Coverage** column appears in all tables.
+The column is omitted when no baseline data is available for a given row.
+
+---
+
+## See also
+
+- [report-groups-format.md](report-groups-format.md) — configuring named report groups
+- [v2-v3-migration-guide.md](v2-v3-migration-guide.md) — upgrading from v2

--- a/docs/report-groups-format.md
+++ b/docs/report-groups-format.md
@@ -180,7 +180,8 @@ It is independent of group thresholds.
 
 ## PR comment structure when groups are configured
 
-When `report-groups` is non-empty the PR comment includes a Groups table between the Global
+When `report-groups` is non-empty and `comment-level` is a detail level (`full`, `changed`,
+`failed`, `failed-or-changed`), the PR comment includes a Groups table between the Global
 summary and the Reports table:
 
 ```text
@@ -197,7 +198,8 @@ summary and the Reports table:
 |…| ← Changed-files table
 ```
 
-When `report-groups` is empty the Groups table is omitted and the three-table structure is used.
+When `report-groups` is empty, or when `comment-level` is `minimal`/`none`, the Groups table is
+omitted.
 
 ---
 

--- a/docs/report-groups-format.md
+++ b/docs/report-groups-format.md
@@ -25,7 +25,10 @@ report-groups: |
 | `name` | **Yes** | string | Non-empty group label. Appears as a row header in the Groups table. |
 | `paths` | **Yes** | list of strings | Glob patterns for JaCoCo XML files belonging to this group. At least one non-empty entry required. |
 | `thresholds` | No | string | `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Each field is a float in `[0, 100)` or empty. Missing fields fall back to `report-thresholds-default`, then to 0.0. |
-| `baseline-paths` | No | list of strings | Glob patterns for baseline XMLs for this group. When present, overrides top-level `baseline-paths` for this group. If omitted, top-level `baseline-paths` can be inherited only when exactly one group omits `baseline-paths`; otherwise inheritance is ambiguous and grouped baseline scans are skipped for omitted groups. |
+| `baseline-paths` | No | list of strings | Glob patterns for baseline XMLs for this group. When present, overrides top-level `baseline-paths` for this group. |
+
+If top-level `baseline-paths` is set and multiple groups omit `baseline-paths`, inheritance is
+ambiguous and grouped baseline scans are skipped for those omitted groups.
 
 ---
 
@@ -82,7 +85,7 @@ report-groups: |
 
 ## Validation rules
 
-The action raises a `ValueError` during startup if:
+Startup input validation fails (logged as action errors, then exits with status 1) if:
 
 - Any group has an empty or missing `name`.
 - Any two groups share the same `name`.

--- a/docs/report-groups-format.md
+++ b/docs/report-groups-format.md
@@ -24,8 +24,8 @@ report-groups: |
 |-------|----------|------|-------------|
 | `name` | **Yes** | string | Non-empty group label. Appears as a row header in the Groups table. |
 | `paths` | **Yes** | list of strings | Glob patterns for JaCoCo XML files belonging to this group. At least one non-empty entry required. |
-| `thresholds` | No | string | `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Each field is a float 0–100 or empty. Missing fields fall back to `report-thresholds-default`, then to 0.0. |
-| `baseline-paths` | No | list of strings | Glob patterns for baseline XMLs for this group. When present, overrides the top-level `baseline-paths` for this group only. |
+| `thresholds` | No | string | `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Each field is a float in `[0, 100)` or empty. Missing fields fall back to `report-thresholds-default`, then to 0.0. |
+| `baseline-paths` | No | list of strings | Glob patterns for baseline XMLs for this group. When present, overrides top-level `baseline-paths` for this group. If omitted, top-level `baseline-paths` can be inherited only when exactly one group omits `baseline-paths`; otherwise inheritance is ambiguous and grouped baseline scans are skipped for omitted groups. |
 
 ---
 
@@ -33,7 +33,7 @@ report-groups: |
 
 The `thresholds` value is three floats separated by `*`:
 
-```
+```text
 overall * changed-files-average * per-changed-file
 ```
 
@@ -45,7 +45,7 @@ overall * changed-files-average * per-changed-file
 
 A field may be left empty to inherit from `report-thresholds-default`:
 
-```
+```text
 80**       →  overall=80, avg=default, per-file=default
 *70*       →  overall=default, avg=70, per-file=default
 80*70*     →  overall=80, avg=70, per-file=default
@@ -53,7 +53,7 @@ A field may be left empty to inherit from `report-thresholds-default`:
 
 ### Threshold resolution order (per field)
 
-```
+```text
 per-group threshold field
     → report-thresholds-default field
         → 0.0
@@ -67,7 +67,7 @@ this fallback chain.
 ## YAML quoting rules
 
 Any glob or threshold value that begins with `*` must be wrapped in quotes to prevent YAML from
-interpreting it as an alias anchor.
+interpreting it as a YAML alias.
 
 ```yaml
 report-groups: |
@@ -85,9 +85,10 @@ report-groups: |
 The action raises a `ValueError` during startup if:
 
 - Any group has an empty or missing `name`.
+- Any two groups share the same `name`.
 - Any group has an empty or missing `paths` list.
 - Any path in `paths` or `baseline-paths` is an empty string.
-- Any threshold field is not a number in [0, 100].
+- Any threshold field is not a number in `[0, 100)`.
 - The YAML block is not valid YAML.
 
 ---
@@ -141,7 +142,11 @@ report-groups: |
     paths:
       - frontend/**/jacoco.xml
     thresholds: '75*65*50'
-    # no baseline-paths — falls back to top-level baseline-paths
+    baseline-paths:
+      - baseline/frontend/**/jacoco.xml
+
+# Note: if top-level baseline-paths is set and multiple groups omit baseline-paths,
+# grouped baseline inheritance is ambiguous and those groups will skip grouped baseline diffs.
 ```
 
 ---
@@ -175,7 +180,7 @@ It is independent of group thresholds.
 When `report-groups` is non-empty the PR comment includes a Groups table between the Global
 summary and the Reports table:
 
-```
+```text
 | Metric (instruction) | Coverage | Threshold | Status |
 |…| ← Global summary (always present)
 

--- a/docs/report-groups-format.md
+++ b/docs/report-groups-format.md
@@ -1,0 +1,200 @@
+# `report-groups` YAML Format Reference
+
+The `report-groups` input lets you organise JaCoCo reports from multi-module projects into named
+groups, each with its own path globs, optional thresholds, and optional baseline paths.
+
+---
+
+## Schema
+
+```yaml
+report-groups: |
+  - name: <string>            # required — group label shown in the PR comment
+    paths:                    # required — one or more glob patterns
+      - <glob>
+      - <glob>
+    thresholds: '<O>*<A>*<P>' # optional — overall * changed-avg * per-file
+    baseline-paths:           # optional — baseline glob patterns for this group
+      - <glob>
+```
+
+### Field reference
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | **Yes** | string | Non-empty group label. Appears as a row header in the Groups table. |
+| `paths` | **Yes** | list of strings | Glob patterns for JaCoCo XML files belonging to this group. At least one non-empty entry required. |
+| `thresholds` | No | string | `overall*changed-files-average*per-changed-file` (e.g. `80*70*60`). Each field is a float 0–100 or empty. Missing fields fall back to `report-thresholds-default`, then to 0.0. |
+| `baseline-paths` | No | list of strings | Glob patterns for baseline XMLs for this group. When present, overrides the top-level `baseline-paths` for this group only. |
+
+---
+
+## Threshold format
+
+The `thresholds` value is three floats separated by `*`:
+
+```
+overall * changed-files-average * per-changed-file
+```
+
+| Position | Dimension | Example |
+|----------|-----------|---------|
+| 1 | Overall coverage (all files in group) | `80` |
+| 2 | Average coverage across changed files | `70` |
+| 3 | Minimum coverage per individual changed file | `60` |
+
+A field may be left empty to inherit from `report-thresholds-default`:
+
+```
+80**       →  overall=80, avg=default, per-file=default
+*70*       →  overall=default, avg=70, per-file=default
+80*70*     →  overall=80, avg=70, per-file=default
+```
+
+### Threshold resolution order (per field)
+
+```
+per-group threshold field
+    → report-thresholds-default field
+        → 0.0
+```
+
+`global-thresholds` is a **separate evaluation pass** over aggregated totals and is never part of
+this fallback chain.
+
+---
+
+## YAML quoting rules
+
+Any glob or threshold value that begins with `*` must be wrapped in quotes to prevent YAML from
+interpreting it as an alias anchor.
+
+```yaml
+report-groups: |
+  - name: backend
+    paths:
+      - '**/jacoco.xml'       # leading * — quotes required
+      - backend/**/jacoco.xml # no leading * — quotes optional
+    thresholds: '80*70*60'    # always quote thresholds (first char after * could be *, too)
+```
+
+---
+
+## Validation rules
+
+The action raises a `ValueError` during startup if:
+
+- Any group has an empty or missing `name`.
+- Any group has an empty or missing `paths` list.
+- Any path in `paths` or `baseline-paths` is an empty string.
+- Any threshold field is not a number in [0, 100].
+- The YAML block is not valid YAML.
+
+---
+
+## Examples
+
+### Minimal — two groups, no per-group thresholds
+
+```yaml
+report-groups: |
+  - name: backend
+    paths:
+      - backend/**/jacoco.xml
+  - name: frontend
+    paths:
+      - frontend/**/jacoco.xml
+```
+
+All groups inherit from `report-thresholds-default` (default `0*0*0` → no enforcement).
+
+---
+
+### Per-group thresholds
+
+```yaml
+report-thresholds-default: '75*60*0'
+report-groups: |
+  - name: backend
+    paths:
+      - backend/**/jacoco.xml
+    thresholds: '80*70*60'   # explicit for all three fields
+  - name: frontend
+    paths:
+      - frontend/**/jacoco.xml
+    thresholds: '75**'       # overall=75; avg and per-file from report-thresholds-default (60 and 0)
+```
+
+---
+
+### Per-group baseline paths
+
+```yaml
+report-groups: |
+  - name: backend
+    paths:
+      - backend/**/jacoco.xml
+    thresholds: '80*70*60'
+    baseline-paths:
+      - baseline/backend/**/jacoco.xml   # overrides top-level baseline-paths for this group
+  - name: frontend
+    paths:
+      - frontend/**/jacoco.xml
+    thresholds: '75*65*50'
+    # no baseline-paths — falls back to top-level baseline-paths
+```
+
+---
+
+### Combined with global thresholds
+
+`global-thresholds` always runs as a separate pass over all reports combined.
+It is independent of group thresholds.
+
+```yaml
+- uses: MoranaApps/jacoco-report@v3
+  with:
+    token: '${{ secrets.GITHUB_TOKEN }}'
+    global-thresholds: '70*0*0'          # aggregated overall must be ≥ 70 %
+    report-thresholds-default: '60*50*0' # default for all groups
+    report-groups: |
+      - name: core
+        paths:
+          - core/**/jacoco.xml
+        thresholds: '80*70*60'           # stricter per-group enforcement
+      - name: plugins
+        paths:
+          - plugins/**/jacoco.xml
+        # no thresholds — uses report-thresholds-default (60*50*0)
+```
+
+---
+
+## PR comment structure when groups are configured
+
+When `report-groups` is non-empty the PR comment includes a Groups table between the Global
+summary and the Reports table:
+
+```
+| Metric (instruction) | Coverage | Threshold | Status |
+|…| ← Global summary (always present)
+
+| Group   | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|…| ← Groups table (present only when report-groups is non-empty)
+
+| Report  | Coverage (O/Ch) | Threshold (O/Ch) | Status (O/Ch) |
+|…| ← Reports table
+
+| File Path | Coverage | Threshold | Status |
+|…| ← Changed-files table
+```
+
+When `report-groups` is empty the Groups table is omitted and the three-table structure is used.
+
+---
+
+## See also
+
+- [comment-level-guide.md](comment-level-guide.md) — controlling comment verbosity
+- [v2-v3-migration-guide.md](v2-v3-migration-guide.md) — migrating `modules` / `modules-thresholds` to `report-groups`
+- [examples/report-groups.yml](../examples/report-groups.yml) — complete workflow example

--- a/docs/v2-v3-migration-guide.md
+++ b/docs/v2-v3-migration-guide.md
@@ -9,7 +9,7 @@ Each section shows a before/after workflow snippet and explains the new behaviou
 
 | # | Area | v2 input | v3 replacement |
 |---|------|----------|---------------|
-| 1 | Threshold inputs | `min-coverage-overall` / `min-coverage-changed-files` / `min-coverage-per-changed-file` | `global-thresholds` |
+| 1 | Threshold inputs | `min-coverage-overall` / `min-coverage-changed-files` / `min-coverage-per-changed-file` | `global-thresholds` (overall + changed-files-average) + `report-thresholds-default` or group `thresholds` (per-changed-file) |
 | 2 | Comment verbosity | `sensitivity` | Removed — detail is always on |
 | 3 | Comment mode | `comment-mode` | Removed — single comment always |
 | 4 | Module grouping | `modules` + `modules-thresholds` | `report-groups` (YAML) |
@@ -19,10 +19,10 @@ Each section shows a before/after workflow snippet and explains the new behaviou
 
 ---
 
-## 1. Threshold inputs → `global-thresholds`
+## 1. Threshold inputs mapping in v3
 
-The three separate threshold inputs are replaced by a single `global-thresholds` string in
-`overall*changed-files-average*per-changed-file` order.
+In v3, overall and changed-files-average thresholds map to `global-thresholds`.
+Per-changed-file thresholds map to `report-thresholds-default` (or per-group `thresholds`).
 
 **v2:**
 ```yaml
@@ -41,11 +41,13 @@ The three separate threshold inputs are replaced by a single `global-thresholds`
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     paths: '**/jacoco.xml'
-    global-thresholds: '80*70*60'
+    global-thresholds: '80*70*0'
+    report-thresholds-default: '0*0*60'
 ```
 
-Each position maps to: `overall * changed-files-average * per-changed-file`.
-Omitted or `0` positions mean no enforcement for that dimension.
+`global-thresholds` uses `overall*changed-files-average*reserved-third`.
+The aggregated evaluation uses overall and changed-files-average values.
+Per-changed-file checks come from report/group thresholds.
 
 ---
 
@@ -296,7 +298,7 @@ v3 adds four new levels. The existing `minimal` and `full` levels are unchanged.
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     paths: '**/jacoco.xml'
-    global-thresholds: '80*70*60'
+    global-thresholds: '80*70*0'
     report-thresholds-default: '75*65*50'
     report-groups: |
       - name: backend

--- a/docs/v2-v3-migration-guide.md
+++ b/docs/v2-v3-migration-guide.md
@@ -208,27 +208,27 @@ in a future release. A deprecation warning is written to the action log when a b
 
 | v2 value | v3 equivalent | Meaning |
 |----------|--------------|---------|
-| `true` | `[overall, changed-files-average, per-changed-file]` | Fail on any threshold breach |
-| `false` | `[]` | Never fail on threshold breach |
+| `true` | `overall,changed-files-average,per-changed-file` | Fail on any threshold breach |
+| `false` | `''` | Never fail on threshold breach |
 
 **v2:**
 ```yaml
     fail-on-threshold: 'true'
 ```
 
-**v3 (explicit list):**
+**v3 (comma-separated):**
 ```yaml
-    fail-on-threshold: '[overall, changed-files-average, per-changed-file]'
+  fail-on-threshold: 'overall,changed-files-average,per-changed-file'
 ```
 
 To fail only on the global overall threshold:
 ```yaml
-    fail-on-threshold: '[overall]'
+  fail-on-threshold: 'overall'
 ```
 
 To disable threshold-based failure entirely:
 ```yaml
-    fail-on-threshold: '[]'
+  fail-on-threshold: ''
 ```
 
 ---
@@ -310,6 +310,6 @@ v3 adds four new levels. The existing `minimal` and `full` levels are unchanged.
           - frontend/**/jacoco.xml
         thresholds: '75*65*50'
     skip-unchanged: 'true'
-    fail-on-threshold: '[overall, changed-files-average, per-changed-file]'
+    fail-on-threshold: 'overall,changed-files-average,per-changed-file'
     comment-level: 'full'
 ```

--- a/docs/v2-v3-migration-guide.md
+++ b/docs/v2-v3-migration-guide.md
@@ -221,10 +221,12 @@ in a future release. A deprecation warning is written to the action log when a b
   fail-on-threshold: 'overall,changed-files-average,per-changed-file'
 ```
 
-To fail only on the global overall threshold:
+To fail only on the overall dimension (global overall plus report/group overall checks):
 ```yaml
   fail-on-threshold: 'overall'
 ```
+
+Note: `overall` is not global-only; report/group overall failures also fail the action.
 
 To disable threshold-based failure entirely:
 ```yaml

--- a/examples/basic.yml
+++ b/examples/basic.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Checkout

--- a/examples/basic.yml
+++ b/examples/basic.yml
@@ -1,0 +1,53 @@
+# examples/basic.yml
+#
+# Minimal JaCoCo Report GitHub Action configuration.
+# Use this as a starting point when you have a single-module project.
+
+name: Coverage Report
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # ------------------------------------------------------------------
+      # Your build step that produces jacoco.xml goes here.
+      # Example for a Maven project:
+      #   - name: Build & test
+      #     run: mvn verify
+      # ------------------------------------------------------------------
+
+      - name: Publish JaCoCo Report
+        uses: MoranaApps/jacoco-report@v3
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+
+          # Path(s) to JaCoCo XML files. Supports glob patterns.
+          paths: '**/jacoco.xml'
+
+          # Global thresholds: overall * changed-files-average * per-changed-file
+          # Set to 0 to disable a dimension.
+          global-thresholds: '80*70*60'
+
+          # Which threshold breaches fail the action.
+          # Leave empty ('') to never fail on thresholds.
+          fail-on-threshold: 'overall,changed-files-average,per-changed-file'
+
+          # Comment verbosity: none | minimal | full | changed | failed | failed-or-changed
+          comment-level: 'full'

--- a/examples/basic.yml
+++ b/examples/basic.yml
@@ -42,9 +42,12 @@ jobs:
           # Path(s) to JaCoCo XML files. Supports glob patterns.
           paths: '**/jacoco.xml'
 
-          # Global thresholds: overall * changed-files-average * per-changed-file
-          # Set to 0 to disable a dimension.
-          global-thresholds: '80*70*60'
+          # Global thresholds: overall * changed-files-average * reserved-third
+          # Per-changed-file checks are configured via report/group thresholds.
+          global-thresholds: '80*70*0'
+
+          # Per-changed-file threshold (overall * changed-files-average * per-changed-file).
+          report-thresholds-default: '0*0*60'
 
           # Which threshold breaches fail the action.
           # Leave empty ('') to never fail on thresholds.

--- a/examples/migration-v2-to-v3.yml
+++ b/examples/migration-v2-to-v3.yml
@@ -1,0 +1,105 @@
+# examples/migration-v2-to-v3.yml
+#
+# Side-by-side before/after showing a complete v2 → v3 migration.
+# See docs/v2-v3-migration-guide.md for detailed explanations.
+
+# ===========================================================================
+# BEFORE — v2 workflow
+# ===========================================================================
+#
+# - uses: MoranaApps/jacoco-report@v2
+#   with:
+#     token: ${{ secrets.GITHUB_TOKEN }}
+#     paths: '**/jacoco.xml'
+#
+#     # Three separate threshold inputs → replaced by global-thresholds
+#     min-coverage-overall: '80'
+#     min-coverage-changed-files: '70'
+#     min-coverage-per-changed-file: '60'
+#
+#     # sensitivity is removed — detail output is always on
+#     sensitivity: 'detail'
+#
+#     # comment-mode is removed — single comment is the only mode
+#     comment-mode: 'single'
+#
+#     # modules + modules-thresholds → replaced by report-groups YAML
+#     modules: |
+#       backend=backend/**/jacoco.xml
+#       frontend=frontend/**/jacoco.xml
+#     modules-thresholds: |
+#       backend=80*70*60
+#       frontend=75*65*50
+#
+#     skip-unchanged: 'true'
+#
+#     # Boolean fail-on-threshold is deprecated → use list form
+#     fail-on-threshold: 'true'
+#
+#     # comment-level had only minimal/full → now six levels available
+#     comment-level: 'full'
+
+# ===========================================================================
+# AFTER — v3 workflow
+# ===========================================================================
+
+name: Coverage Report
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Publish JaCoCo Report
+        uses: MoranaApps/jacoco-report@v3
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+
+          # global-thresholds replaces the three separate min-coverage-* inputs.
+          # Format: overall * changed-files-average * per-changed-file
+          global-thresholds: '80*70*60'
+
+          # report-thresholds-default sets the fallback for group threshold fields.
+          report-thresholds-default: '75*65*50'
+
+          # report-groups replaces modules + modules-thresholds.
+          # Each group defines its own paths and optional per-group thresholds.
+          report-groups: |
+            - name: backend
+              paths:
+                - backend/**/jacoco.xml
+              thresholds: '80*70*60'
+            - name: frontend
+              paths:
+                - frontend/**/jacoco.xml
+              thresholds: '75*65*50'
+
+          # skip-unchanged now filters at scan stage (before evaluation).
+          skip-unchanged: 'true'
+
+          # evaluate-unchanged=true (default): filtered reports still checked
+          # against their overall threshold even though they are hidden from the comment.
+          evaluate-unchanged: 'true'
+
+          # List form replaces deprecated boolean fail-on-threshold.
+          fail-on-threshold: 'overall,changed-files-average,per-changed-file'
+
+          # comment-level: same values as v2 (minimal/full) plus four new ones:
+          # none | changed | failed | failed-or-changed
+          comment-level: 'full'

--- a/examples/migration-v2-to-v3.yml
+++ b/examples/migration-v2-to-v3.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      # ------------------------------------------------------------------
+      # Your build/test step goes here — it must generate the JaCoCo XML
+      # files referenced by report-groups before publishing the report.
+      # ------------------------------------------------------------------
+
       - name: Publish JaCoCo Report
         uses: MoranaApps/jacoco-report@v3
         with:

--- a/examples/migration-v2-to-v3.yml
+++ b/examples/migration-v2-to-v3.yml
@@ -12,7 +12,9 @@
 #     token: ${{ secrets.GITHUB_TOKEN }}
 #     paths: '**/jacoco.xml'
 #
-#     # Three separate threshold inputs → replaced by global-thresholds
+#     # v2 threshold inputs map in v3 as:
+#     # - overall + changed-files-average -> global-thresholds
+#     # - per-changed-file -> report-thresholds-default / group thresholds
 #     min-coverage-overall: '80'
 #     min-coverage-changed-files: '70'
 #     min-coverage-per-changed-file: '60'
@@ -72,9 +74,9 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
-          # global-thresholds replaces the three separate min-coverage-* inputs.
-          # Format: overall * changed-files-average * per-changed-file
-          global-thresholds: '80*70*60'
+          # global-thresholds carries aggregated overall + changed-files-average.
+          # Per-changed-file threshold is configured via report/group thresholds.
+          global-thresholds: '80*70*0'
 
           # report-thresholds-default sets the fallback for group threshold fields.
           report-thresholds-default: '75*65*50'

--- a/examples/migration-v2-to-v3.yml
+++ b/examples/migration-v2-to-v3.yml
@@ -55,7 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Checkout

--- a/examples/report-groups.yml
+++ b/examples/report-groups.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -53,11 +54,15 @@ jobs:
               paths:
                 - backend/**/jacoco.xml
               thresholds: '80*70*60'   # explicit for all three fields
+              baseline-paths:
+                - baseline/backend/**/*.xml
 
             - name: frontend
               paths:
                 - frontend/**/jacoco.xml
               thresholds: '75**'       # overall=75; avg and per-file from report-thresholds-default
+              baseline-paths:
+                - baseline/frontend/**/*.xml
 
             - name: shared-libs
               paths:
@@ -66,8 +71,8 @@ jobs:
               baseline-paths:
                 - baseline/libs/**/*.xml   # per-group baseline overrides top-level baseline-paths
 
-          # Top-level baseline paths used by groups that do not define their own.
-          baseline-paths: 'baseline/main/**/*.xml'
+          # Optional top-level baseline paths (used only when exactly one group omits baseline-paths).
+          # baseline-paths: 'baseline/main/**/*.xml'
 
           # Show all tables; hide rows with no changed files to reduce noise.
           comment-level: 'failed-or-changed'

--- a/examples/report-groups.yml
+++ b/examples/report-groups.yml
@@ -1,0 +1,79 @@
+# examples/report-groups.yml
+#
+# Multi-module project using report-groups for per-group thresholds.
+# Each group scans its own set of JaCoCo XML files and is evaluated
+# independently. A global threshold is applied to the aggregated totals
+# as a separate pass.
+
+name: Coverage Report (multi-module)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # ------------------------------------------------------------------
+      # Your build step goes here — it must produce jacoco.xml files for
+      # each module before this action runs.
+      # ------------------------------------------------------------------
+
+      - name: Publish JaCoCo Report
+        uses: MoranaApps/jacoco-report@v3
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+
+          # Global thresholds are evaluated over all reports combined,
+          # independently of per-group thresholds.
+          global-thresholds: '75*0*0'
+
+          # Default thresholds applied per-field when a group omits a field.
+          # Resolution order: per-group field → this default → 0.0
+          report-thresholds-default: '70*60*0'
+
+          # Named report groups. When report-groups is set, top-level
+          # paths can be omitted — each group defines its own paths.
+          report-groups: |
+            - name: backend
+              paths:
+                - backend/**/jacoco.xml
+              thresholds: '80*70*60'   # explicit for all three fields
+
+            - name: frontend
+              paths:
+                - frontend/**/jacoco.xml
+              thresholds: '75**'       # overall=75; avg and per-file from report-thresholds-default
+
+            - name: shared-libs
+              paths:
+                - libs/**/jacoco.xml
+              # no thresholds — fully inherits from report-thresholds-default (70*60*0)
+              baseline-paths:
+                - baseline/libs/**/*.xml   # per-group baseline overrides top-level baseline-paths
+
+          # Top-level baseline paths used by groups that do not define their own.
+          baseline-paths: 'baseline/main/**/*.xml'
+
+          # Show all tables; hide rows with no changed files to reduce noise.
+          comment-level: 'failed-or-changed'
+
+          # Fail on overall and changed-files-average threshold breaches.
+          fail-on-threshold: 'overall,changed-files-average'
+
+          # Update the existing comment rather than posting a new one each push.
+          update-comment: 'true'

--- a/examples/report-groups.yml
+++ b/examples/report-groups.yml
@@ -74,7 +74,7 @@ jobs:
           # Optional top-level baseline paths (used only when exactly one group omits baseline-paths).
           # baseline-paths: 'baseline/main/**/*.xml'
 
-          # Show all tables; hide rows with no changed files to reduce noise.
+          # Show rows with changes or failures; rows with no changes are still shown when failing.
           comment-level: 'failed-or-changed'
 
           # Fail on overall and changed-files-average threshold breaches.


### PR DESCRIPTION
## Overview
This PR improves repository documentation and onboarding materials for the JaCoCo Report GitHub Action, with clearer guidance and ready-to-use workflow examples.

## Scope Of Changes
- Updated core documentation files.
- Added a comment-level guide.
- Added a report-groups format guide.
- Added example workflows for basic usage, report groups, and migration from v2 to v3.

## Related
Closes #70
Closes #98 

Release Notes:
- Expanded and reorganized core project documentation to improve setup, usage, and maintenance guidance.
- Added dedicated guides for comment-level behavior and report-groups configuration.
- Added practical YAML examples for basic usage, report groups, and v2 to v3 migration.
- No production runtime logic was changed; this is a docs and examples update.
