### PR TITLE
test: add tests for WRITE_SNAPSHOTS regeneration guard functionality

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -84,7 +84,7 @@ Group 0 (deps) → Task 20 🔝 → Tasks 17/18/21 → Group F (design decisions
 | **42** | J | Document `report-groups` YAML format | ✅ | `docs/improve-docs` | #98 |
 | **43** | J | Create `examples/` directory | ✅ | `docs/improve-docs` | new |
 | **44** | K | Remove `# pylint: disable` inline suppressions | ✅ | `fix/95-remove-pylint-inline-disables` | #95 |
-| **45** | K | `WRITE_SNAPSHOTS` regeneration guard | 🔒 ⬜ | `chore/snapshot-write-guard` | new |
+| **45** | K | `WRITE_SNAPSHOTS` regeneration guard | ✅ | `chore/snapshot-write-guard` | new |
 | **46** | L | Introduce Pydantic for validation | ⬜ | `feature/39-pydantic-input-validation` | #39 |
 | **47** | L | SPIKE: auto-detect modules from sbt/mvn | ⬜ | `spike/71-auto-detect-modules-sbt-mvn` | #71 |
 | **48** | L | Copilot GitHub Marketplace support | ✅ | `chore/136-copilot-marketplace-support` | #136 |
@@ -560,7 +560,7 @@ Replace inline disables with proper code fixes or `.pylintrc` entries with docum
 
 Status note: repository audit confirms there are no inline `# pylint: disable` suppressions remaining in tracked Python files.
 
-#### Task 45 — `WRITE_SNAPSHOTS` regeneration guard ⬜
+#### Task 45 — `WRITE_SNAPSHOTS` regeneration guard ✅
 
 **Branch:** `chore/snapshot-write-guard` | **Issue:** new
 **Depends on:** Task 33

--- a/tests/integration/test_golden_snapshots.py
+++ b/tests/integration/test_golden_snapshots.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.integration.helpers import (
@@ -73,6 +74,27 @@ def _assert_or_write_snapshot(scenario: str, actual: str) -> None:
         "If this change is intentional, regenerate with: "
         "WRITE_SNAPSHOTS=1 pytest tests/integration/test_golden_snapshots.py"
     )
+
+
+def test_assert_or_write_snapshot_writes_fixture_when_guard_enabled(monkeypatch, tmp_path: Path) -> None:
+    """WRITE_SNAPSHOTS=1 writes the snapshot instead of asserting against existing fixtures."""
+    monkeypatch.setenv("WRITE_SNAPSHOTS", "1")
+    monkeypatch.setattr("tests.integration.test_golden_snapshots.FIXTURES_DIR", tmp_path)
+
+    _assert_or_write_snapshot("guard_case", "snapshot body")
+
+    written = tmp_path / "snapshot_guard_case.md"
+    assert written.exists()
+    assert written.read_text(encoding="utf-8") == "snapshot body"
+
+
+def test_assert_or_write_snapshot_missing_fixture_has_regen_hint(monkeypatch, tmp_path: Path) -> None:
+    """Without WRITE_SNAPSHOTS, missing fixture should fail with regeneration guidance."""
+    monkeypatch.delenv("WRITE_SNAPSHOTS", raising=False)
+    monkeypatch.setattr("tests.integration.test_golden_snapshots.FIXTURES_DIR", tmp_path)
+
+    with pytest.raises(AssertionError, match="WRITE_SNAPSHOTS=1"):
+        _assert_or_write_snapshot("missing_case", "snapshot body")
 
 
 def test_snapshot_no_groups(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Overview

Adds explicit test coverage for the `WRITE_SNAPSHOTS=1` regeneration guard in the golden snapshot test suite.

Previously, the `assert_or_write_snapshot` helper had no tests verifying that it writes fixtures when the guard is enabled or that it surfaces a helpful regeneration hint on failure.

Release Notes:

- `test_assert_or_write_snapshot_writes_fixture_when_guard_enabled`: asserts the helper writes the fixture file to disk when `WRITE_SNAPSHOTS=1` is set.
- `test_assert_or_write_snapshot_missing_fixture_has_regen_hint`: asserts the error message contains a `WRITE_SNAPSHOTS=1` hint when the fixture file is absent.
