### PR TITLE
fix: resolve report name collisions by using file paths for unique identification

### DIFF
--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -96,8 +96,10 @@ class CoverageEvaluator:
         changed_file_counter = 0
 
         # evaluation of all report files (report == input xml file)
+        seen_report_names: set[str] = set()
         for report in self._report_files_coverage:
             evaluated_coverage_report: EvaluatedReportCoverage = EvaluatedReportCoverage(report.name, report.group_name)
+            evaluated_coverage_report.path = report.path
 
             # get report's overall values
             mi, co = report.overall_coverage.get_values_by_metric(m)
@@ -120,14 +122,16 @@ class CoverageEvaluator:
                 evaluated_coverage_report.avg_changed_files_coverage.coverage()
             )
 
-            # save the evaluated report
-            if report.name in self.evaluated_reports_coverage:
+            # Warn about duplicate XML report name; keying by path prevents data loss.
+            if report.name in seen_report_names:
                 logger.warning(
-                    "Duplicate report name '%s' detected; earlier evaluation data will be overwritten."
-                    " Ensure each report has a unique name to avoid incorrect threshold results.",
+                    "Duplicate report name '%s' detected; using file path as unique key to prevent"
+                    " data collision. Consider setting a unique <title> per module in the Maven"
+                    " JaCoCo plugin to avoid confusion in the PR comment.",
                     report.name,
                 )
-            self.evaluated_reports_coverage[report.name] = self._evaluate_report(report, evaluated_coverage_report)
+            seen_report_names.add(report.name)
+            self.evaluated_reports_coverage[report.path] = self._evaluate_report(report, evaluated_coverage_report)
 
         # evaluation of all groups (group == named set of reports with common paths/thresholds)
         for group in self._report_groups:
@@ -215,16 +219,17 @@ class CoverageEvaluator:
         report_violations: list[str] = []
         changed_files_violations: list[str] = []
 
-        for report_path, evaluated_coverage_report in self.evaluated_reports_coverage.items():
+        for evaluated_coverage_report in self.evaluated_reports_coverage.values():
+            report_display = evaluated_coverage_report.name
             if not evaluated_coverage_report.overall_passed:
                 report_violations.append(
-                    f"Report '{report_path}' overall coverage {evaluated_coverage_report.overall_coverage_reached} "
+                    f"Report '{report_display}' overall coverage {evaluated_coverage_report.overall_coverage_reached} "
                     f"is below the threshold {evaluated_coverage_report.overall_coverage_threshold}."
                 )
                 self.reached_threshold_overall = False
             if not evaluated_coverage_report.avg_changed_files_passed:
                 report_violations.append(
-                    f"Report '{report_path}' changed files coverage "
+                    f"Report '{report_display}' changed files coverage "
                     f"{evaluated_coverage_report.avg_changed_files_coverage_reached} is below the threshold "
                     f"{evaluated_coverage_report.changed_files_threshold}."
                 )
@@ -232,7 +237,7 @@ class CoverageEvaluator:
             for key, passed in evaluated_coverage_report.changed_files_passed.items():
                 if not passed:
                     changed_files_violations.append(
-                        f"Report '{report_path}' changed file '{key}' coverage "
+                        f"Report '{report_display}' changed file '{key}' coverage "
                         f"{evaluated_coverage_report.changed_files_coverage_reached[key]} is below the threshold "
                         f"{evaluated_coverage_report.per_changed_file_threshold}."
                     )

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -277,8 +277,7 @@ class PRCommentGenerator:
             bs_covered_ch += bs.avg_changed_files_coverage.covered
 
         global_total_o = sum(
-            erc.overall_coverage.covered + erc.overall_coverage.missed
-            for erc in curr_by_path.values()
+            erc.overall_coverage.covered + erc.overall_coverage.missed for erc in curr_by_path.values()
         )
         global_total_ch = sum(
             erc.avg_changed_files_coverage.covered + erc.avg_changed_files_coverage.missed
@@ -547,9 +546,7 @@ class PRCommentGenerator:
 
         group_name = evaluated_coverage.name
         curr_in_group = {
-            path: erc
-            for path, erc in self.evaluator.evaluated_reports_coverage.items()
-            if erc.group_name == group_name
+            path: erc for path, erc in self.evaluator.evaluated_reports_coverage.items() if erc.group_name == group_name
         }
 
         bs_reports = getattr(self.bs_evaluator, "evaluated_reports_coverage", {})
@@ -608,9 +605,7 @@ class PRCommentGenerator:
             return 0.0, 0.0
 
         diff_o = evaluated_coverage.overall_coverage_reached - bs_coverage.overall_coverage_reached
-        diff_ch = (
-            evaluated_coverage.avg_changed_files_coverage_reached - bs_coverage.avg_changed_files_coverage_reached
-        )
+        diff_ch = evaluated_coverage.avg_changed_files_coverage_reached - bs_coverage.avg_changed_files_coverage_reached
         return diff_o, diff_ch
 
     # Full example of the table

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -250,19 +250,27 @@ class PRCommentGenerator:
         )
 
     def _compute_matched_global_diffs(self, bs_evaluator: "CoverageEvaluator") -> tuple[float, float]:
-        """Return (diff_overall, diff_changed) using only report names present in both evaluators."""
-        matched_names = set(self.evaluator.evaluated_reports_coverage.keys()) & set(
-            bs_evaluator.evaluated_reports_coverage.keys()
-        )
-        if not matched_names:
+        """Return (diff_overall, diff_changed) using reports matched between both evaluators.
+
+        Matching is path-first (same directory structure) with a name-based fallback for setups
+        where current and baseline reports live in different directory trees.
+        """
+        curr_by_path = self.evaluator.evaluated_reports_coverage
+        bs_by_path = bs_evaluator.evaluated_reports_coverage
+
+        matched_paths = set(curr_by_path.keys()) & set(bs_by_path.keys())
+        if matched_paths:
+            pairs = [(curr_by_path[p], bs_by_path[p]) for p in matched_paths]
+        else:
+            bs_by_name = {v.name: v for v in bs_by_path.values()}
+            pairs = [(curr, bs_by_name[curr.name]) for curr in curr_by_path.values() if curr.name in bs_by_name]
+
+        if not pairs:
             return 0.0, 0.0
 
         curr_covered_o = bs_covered_o = 0
         curr_covered_ch = bs_covered_ch = 0
-
-        for name in matched_names:
-            curr = self.evaluator.evaluated_reports_coverage[name]
-            bs = bs_evaluator.evaluated_reports_coverage[name]
+        for curr, bs in pairs:
             curr_covered_o += curr.overall_coverage.covered
             bs_covered_o += bs.overall_coverage.covered
             curr_covered_ch += curr.avg_changed_files_coverage.covered
@@ -270,11 +278,11 @@ class PRCommentGenerator:
 
         global_total_o = sum(
             erc.overall_coverage.covered + erc.overall_coverage.missed
-            for erc in self.evaluator.evaluated_reports_coverage.values()
+            for erc in curr_by_path.values()
         )
         global_total_ch = sum(
             erc.avg_changed_files_coverage.covered + erc.avg_changed_files_coverage.missed
-            for erc in self.evaluator.evaluated_reports_coverage.values()
+            for erc in curr_by_path.values()
         )
 
         diff_o = round((curr_covered_o - bs_covered_o) / global_total_o * 100, 2) if global_total_o > 0 else 0.0
@@ -513,56 +521,64 @@ class PRCommentGenerator:
         return s
 
     def _sorted_report_keys(self, evaluated_reports_coverage: dict[str, EvaluatedReportCoverage]) -> list[str]:
-        """Return report keys sorted by configured group order, then report name."""
+        """Return report keys sorted by configured group order, then by display name."""
         group_order = getattr(self.evaluator, "report_group_order", [])
         if not group_order:
-            return sorted(list(evaluated_reports_coverage.keys()))
+            return sorted(
+                list(evaluated_reports_coverage.keys()),
+                key=lambda k: evaluated_reports_coverage[k].name,
+            )
 
         group_index: dict[str, int] = {name: idx for idx, name in enumerate(group_order)}
         fallback_index = len(group_index)
 
         return sorted(
             list(evaluated_reports_coverage.keys()),
-            key=lambda report_name: (
-                group_index.get(evaluated_reports_coverage[report_name].group_name, fallback_index),
-                report_name,
+            key=lambda k: (
+                group_index.get(evaluated_reports_coverage[k].group_name, fallback_index),
+                evaluated_reports_coverage[k].name,
             ),
         )
 
     def calculate_baseline_group_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
-        """Calculate baseline deltas for one rendered group row using only matched report names."""
+        """Calculate baseline deltas for one rendered group row using path-first, name-fallback matching."""
         if not self.bs_evaluator or evaluated_coverage.name not in self.bs_evaluator.evaluated_groups_coverage:
             return 0.0, 0.0
 
         group_name = evaluated_coverage.name
-        matched_names = {
-            name
-            for name, erc in self.evaluator.evaluated_reports_coverage.items()
-            if erc.group_name == group_name and name in self.bs_evaluator.evaluated_reports_coverage
+        curr_in_group = {
+            path: erc
+            for path, erc in self.evaluator.evaluated_reports_coverage.items()
+            if erc.group_name == group_name
         }
-        if not matched_names:
+
+        bs_reports = getattr(self.bs_evaluator, "evaluated_reports_coverage", {})
+        bs_reports = bs_reports if isinstance(bs_reports, dict) else {}
+
+        matched_paths = set(curr_in_group.keys()) & set(bs_reports.keys())
+        if matched_paths:
+            pairs = [(curr_in_group[p], bs_reports[p]) for p in matched_paths]
+        else:
+            bs_by_name = {v.name: v for v in bs_reports.values()}
+            pairs = [(curr, bs_by_name[curr.name]) for curr in curr_in_group.values() if curr.name in bs_by_name]
+
+        if not pairs:
             return 0.0, 0.0
 
         curr_covered_o = bs_covered_o = 0
         curr_covered_ch = bs_covered_ch = 0
-
-        for name in matched_names:
-            curr = self.evaluator.evaluated_reports_coverage[name]
-            bs = self.bs_evaluator.evaluated_reports_coverage[name]
+        for curr, bs in pairs:
             curr_covered_o += curr.overall_coverage.covered
             bs_covered_o += bs.overall_coverage.covered
             curr_covered_ch += curr.avg_changed_files_coverage.covered
             bs_covered_ch += bs.avg_changed_files_coverage.covered
 
         group_total_o = sum(
-            erc.overall_coverage.covered + erc.overall_coverage.missed
-            for erc in self.evaluator.evaluated_reports_coverage.values()
-            if erc.group_name == group_name
+            erc.overall_coverage.covered + erc.overall_coverage.missed for erc in curr_in_group.values()
         )
         group_total_ch = sum(
             erc.avg_changed_files_coverage.covered + erc.avg_changed_files_coverage.missed
-            for erc in self.evaluator.evaluated_reports_coverage.values()
-            if erc.group_name == group_name
+            for erc in curr_in_group.values()
         )
 
         diff_o = round((curr_covered_o - bs_covered_o) / group_total_o * 100, 2) if group_total_o > 0 else 0.0
@@ -570,20 +586,31 @@ class PRCommentGenerator:
 
         return diff_o, diff_ch
 
+    def _find_baseline_report(self, evaluated_coverage: EvaluatedReportCoverage) -> Optional["EvaluatedReportCoverage"]:
+        """Return the matching baseline EvaluatedReportCoverage, or None.
+
+        Tries path-based lookup first (same directory structure), then falls back to name-based
+        matching for setups where current and baseline reports live in different directory trees.
+        """
+        if not self.bs_evaluator:
+            return None
+        bs = getattr(self.bs_evaluator, "evaluated_reports_coverage", {})
+        if not isinstance(bs, dict):
+            return None
+        if evaluated_coverage.path and evaluated_coverage.path in bs:
+            return bs[evaluated_coverage.path]
+        return next((v for v in bs.values() if v.name == evaluated_coverage.name), None)
+
     def _calculate_baseline_report_diffs(self, evaluated_coverage: EvaluatedReportCoverage) -> tuple[float, float]:
         """Calculate baseline deltas for one rendered report row."""
-        if not self.bs_evaluator or evaluated_coverage.name not in self.bs_evaluator.evaluated_reports_coverage.keys():
+        bs_coverage = self._find_baseline_report(evaluated_coverage)
+        if bs_coverage is None:
             return 0.0, 0.0
 
-        diff_o = (
-            evaluated_coverage.overall_coverage_reached
-            - self.bs_evaluator.evaluated_reports_coverage[evaluated_coverage.name].overall_coverage_reached
-        )
+        diff_o = evaluated_coverage.overall_coverage_reached - bs_coverage.overall_coverage_reached
         diff_ch = (
-            evaluated_coverage.avg_changed_files_coverage_reached
-            - self.bs_evaluator.evaluated_reports_coverage[evaluated_coverage.name].avg_changed_files_coverage_reached
+            evaluated_coverage.avg_changed_files_coverage_reached - bs_coverage.avg_changed_files_coverage_reached
         )
-
         return diff_o, diff_ch
 
     # Full example of the table
@@ -692,34 +719,29 @@ class PRCommentGenerator:
 
         lines = []
         for ecr_key in evaluated_reports_coverage.keys():
-            for file_key in evaluated_reports_coverage[ecr_key].changed_files_coverage_reached.keys():
+            curr_erc = evaluated_reports_coverage[ecr_key]
+            bs_erc = self._find_baseline_report(curr_erc)
+            for file_key in curr_erc.changed_files_coverage_reached.keys():
                 filename = _escape_md_link_text(os.path.basename(file_key))
                 file_hash = hashlib.sha256(file_key.encode("utf-8")).hexdigest()
                 file_as_link_to_diff = (
                     f"https://github.com/{self.github_repository}/pull/{self.pr_number}/files#diff-{file_hash}"
                 )
 
-                if not self.bs_evaluator:
-                    diff = 0.0
-                elif ecr_key not in self.bs_evaluator.evaluated_reports_coverage.keys():
-                    diff = 0.0
-                elif (
-                    file_key
-                    not in self.bs_evaluator.evaluated_reports_coverage[ecr_key].changed_files_coverage_reached.keys()
-                ):
+                if bs_erc is None or file_key not in bs_erc.changed_files_coverage_reached:
                     diff = 0.0
                 else:
                     diff = (
-                        evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]
-                        - self.bs_evaluator.evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]
+                        curr_erc.changed_files_coverage_reached[file_key]
+                        - bs_erc.changed_files_coverage_reached[file_key]
                     )
 
                 line = (
                     f"\n| [{filename}]({file_as_link_to_diff})"
-                    f" | {evaluated_reports_coverage[ecr_key].changed_files_coverage_reached[file_key]}%"
-                    f" | {evaluated_reports_coverage[ecr_key].per_changed_file_threshold}%"
+                    f" | {curr_erc.changed_files_coverage_reached[file_key]}%"
+                    f" | {curr_erc.per_changed_file_threshold}%"
                     f" | {'+' if diff > 0.001 else ''}{round(diff, 2)}%"
-                    f" | {p if evaluated_reports_coverage[ecr_key].changed_files_passed[file_key] else f} |"
+                    f" | {p if curr_erc.changed_files_passed[file_key] else f} |"
                 )
                 lines.append(line)
 

--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -320,7 +320,7 @@ class JaCoCoReport:
         self.reached_threshold_per_change_file = evaluator_for_results.reached_threshold_per_change_file
 
         if fail_unchanged_enabled and filtered_unchanged_reports:
-            filtered_unchanged_report_names = {report.name for report in filtered_unchanged_reports}
+            filtered_unchanged_report_names = {report.path for report in filtered_unchanged_reports}
             self.reached_threshold_fail_unchanged = all(
                 evaluated_report.overall_passed
                 for report_name, evaluated_report in evaluator_for_results.evaluated_reports_coverage.items()
@@ -332,7 +332,7 @@ class JaCoCoReport:
         # generate the comment(s)
         logger.info("Generating PR comment(s).")
         skip_report_names: frozenset[str] = (
-            frozenset(r.name for r in filtered_unchanged_reports)
+            frozenset(r.path for r in filtered_unchanged_reports)
             if skip_unchanged and evaluate_filtered_unchanged and filtered_unchanged_reports
             else frozenset()
         )

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -10,8 +10,9 @@ class EvaluatedReportCoverage:
     A class that represents an evaluated coverage of one report file or report group.
     """
 
-    def __init__(self, name: str = "Unknown", group_name: str = "Unknown"):
+    def __init__(self, name: str = "Unknown", group_name: str = "Unknown", path: str = ""):
         self.name: str = name
+        self.path: str = path
         self.group_name: str = group_name
 
         # PR comment data
@@ -36,6 +37,7 @@ class EvaluatedReportCoverage:
         """Convert object to dictionary for JSON serialization"""
         return {
             "name": self.name,
+            "path": self.path,
             "group_name": self.group_name,
             "overall_passed": self.overall_passed,
             "overall_coverage_reached": self.overall_coverage_reached,
@@ -55,7 +57,7 @@ class EvaluatedReportCoverage:
 
     def clone(self) -> "EvaluatedReportCoverage":
         """Return a detached copy of the evaluated coverage object."""
-        clone = EvaluatedReportCoverage(self.name, self.group_name)
+        clone = EvaluatedReportCoverage(self.name, self.group_name, self.path)
         clone.overall_passed = self.overall_passed
         clone.overall_coverage_reached = self.overall_coverage_reached
         clone.overall_coverage_threshold = self.overall_coverage_threshold

--- a/tests/unit/evaluator/test_coverage_evaluator.py
+++ b/tests/unit/evaluator/test_coverage_evaluator.py
@@ -140,7 +140,7 @@ def test_review_violations_report_overall_coverage_below_threshold(evaluator, mo
     }
     evaluator.review_violations()
 
-    assert "Report 'filepath' overall coverage 40.0 is below the threshold 50.0." in evaluator.violations
+    assert "Report 'module-a' overall coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
 def test_review_violations_report_changed_files_coverage_below_threshold(evaluator, mocker: MockerFixture):
     evaluator.total_coverage_overall = 75.0
@@ -169,7 +169,7 @@ def test_review_violations_report_changed_files_coverage_below_threshold(evaluat
     }
     evaluator.review_violations()
 
-    assert "Report 'filepath' changed files coverage 40.0 is below the threshold 50.0." in evaluator.violations
+    assert "Report 'module-a' changed files coverage 40.0 is below the threshold 50.0." in evaluator.violations
 
 def test_evaluate_group_with_zero_coverage(caplog):
     # Create a sample report file coverage
@@ -248,7 +248,7 @@ def test_threshold_uses_group_when_matched(mocker: MockerFixture):
         report_groups=[group],
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-a"]
+    ev = evaluator.evaluated_reports_coverage["report-a.xml"]
     assert ev.overall_coverage_threshold == 70.0
     assert ev.changed_files_threshold == 60.0
     assert ev.per_changed_file_threshold == 50.0
@@ -267,7 +267,7 @@ def test_threshold_falls_back_to_report_thresholds_default_when_no_group_matches
         report_thresholds_default=(55.0, 45.0, 35.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-b"]
+    ev = evaluator.evaluated_reports_coverage["report-b.xml"]
     # fallback chain: group field → report-thresholds-default → 0.0 (global NOT in chain)
     assert ev.overall_coverage_threshold == 55.0
     assert ev.changed_files_threshold == 45.0
@@ -286,7 +286,7 @@ def test_threshold_partial_group_thresholds_fall_back_to_report_thresholds_defau
         report_thresholds_default=(55.0, 45.0, 35.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-c"]
+    ev = evaluator.evaluated_reports_coverage["report-c.xml"]
     # overall is set on the group; changed_files and per_file fall back to report_thresholds_default
     assert ev.overall_coverage_threshold == 70.0
     assert ev.changed_files_threshold == 45.0
@@ -314,7 +314,7 @@ def test_report_thresholds_default_fallback_all_explicit(mocker: MockerFixture):
         report_thresholds_default=(55.0, 45.0, 35.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-a"]
+    ev = evaluator.evaluated_reports_coverage["report-a.xml"]
     assert ev.overall_coverage_threshold == 80.0
     assert ev.changed_files_threshold == 70.0
     assert ev.per_changed_file_threshold == 60.0
@@ -333,7 +333,7 @@ def test_report_thresholds_default_fallback_from_default(mocker: MockerFixture):
         report_thresholds_default=(75.0, 60.0, 40.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-b"]
+    ev = evaluator.evaluated_reports_coverage["report-b.xml"]
     assert ev.overall_coverage_threshold == 75.0
     assert ev.changed_files_threshold == 60.0
     assert ev.per_changed_file_threshold == 40.0
@@ -352,7 +352,7 @@ def test_report_thresholds_default_fallback_to_zero(mocker: MockerFixture):
         report_thresholds_default=(0.0, 0.0, 0.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-c"]
+    ev = evaluator.evaluated_reports_coverage["report-c.xml"]
     assert ev.overall_coverage_threshold == 0.0
     assert ev.changed_files_threshold == 0.0
     assert ev.per_changed_file_threshold == 0.0
@@ -371,7 +371,7 @@ def test_report_thresholds_default_field_level_mix(mocker: MockerFixture):
         report_thresholds_default=(75.0, 60.0, 0.0),
     )
     evaluator.evaluate()
-    ev = evaluator.evaluated_reports_coverage["report-d"]
+    ev = evaluator.evaluated_reports_coverage["report-d.xml"]
     assert ev.overall_coverage_threshold == 80.0   # from group
     assert ev.changed_files_threshold == 60.0       # from report_thresholds_default
     assert ev.per_changed_file_threshold == 0.0     # from report_thresholds_default
@@ -579,7 +579,7 @@ def test_report_overall_coverage_logged_as_na_when_no_metric_weight(mocker: Mock
     messages = [r.message for r in caplog.records]
     assert "Report 'na_report' has no overall coverage data for selected metric; treated as passed." in messages
     assert not any("Report 'na_report' reached overall coverage" in m for m in messages)
-    assert evaluator.evaluated_reports_coverage["na_report"].overall_passed is True
+    assert evaluator.evaluated_reports_coverage["na_report.xml"].overall_passed is True
 
 
 def test_report_changed_files_coverage_logged_as_na_when_no_metric_weight(mocker: MockerFixture, caplog):
@@ -623,7 +623,7 @@ def test_report_changed_files_coverage_logged_as_na_when_no_metric_weight(mocker
     messages = [r.message for r in caplog.records]
     assert "Report 'na_cf_report' has no changed-files coverage data for selected metric; treated as passed." in messages
     assert not any("Report 'na_cf_report' reached average changed files coverage" in m for m in messages)
-    assert evaluator.evaluated_reports_coverage["na_cf_report"].avg_changed_files_passed is True
+    assert evaluator.evaluated_reports_coverage["na_cf_report.xml"].avg_changed_files_passed is True
 
 
 def test_report_changed_files_coverage_logged_for_changed_report(mocker: MockerFixture, caplog):
@@ -777,10 +777,10 @@ def _make_report_with_changed_file_instruction(
 # ---------------------------------------------------------------------------
 
 def test_duplicate_report_name_emits_warning(make_report_file_coverage, mocker, caplog):
-    """Evaluator logs a WARNING when two reports share the same name (title)."""
+    """Evaluator logs a WARNING when two reports share the same XML name (title)."""
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
-    report_a = make_report_file_coverage(name="same-name")
-    report_b = make_report_file_coverage(name="same-name")
+    report_a = make_report_file_coverage(path="module-a/jacoco.xml", name="same-name")
+    report_b = make_report_file_coverage(path="module-b/jacoco.xml", name="same-name")
 
     evaluator = CoverageEvaluator(
         report_files_coverage=[report_a, report_b],
@@ -792,6 +792,24 @@ def test_duplicate_report_name_emits_warning(make_report_file_coverage, mocker, 
         evaluator.evaluate()
 
     assert "Duplicate report name 'same-name' detected" in caplog.text
+
+
+def test_duplicate_report_name_does_not_lose_data(make_report_file_coverage, mocker):
+    """When two reports share the XML name but have different paths, both are preserved."""
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    report_a = make_report_file_coverage(path="module-a/jacoco.xml", name="JaCoCo Coverage Report")
+    report_b = make_report_file_coverage(path="module-b/jacoco.xml", name="JaCoCo Coverage Report")
+
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[report_a, report_b],
+        global_min_coverage_overall=0.0,
+        global_min_coverage_changed_files=0.0,
+    )
+    evaluator.evaluate()
+
+    assert "module-a/jacoco.xml" in evaluator.evaluated_reports_coverage
+    assert "module-b/jacoco.xml" in evaluator.evaluated_reports_coverage
+    assert len(evaluator.evaluated_reports_coverage) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generator/test_pr_comment_generator.py
+++ b/tests/unit/generator/test_pr_comment_generator.py
@@ -1222,7 +1222,7 @@ def test_baseline_report_matched_by_name(make_report_file_coverage, make_coverag
     pr_comment_generator.evaluator = evaluator
     pr_comment_generator.bs_evaluator = bs_evaluator
 
-    ev = evaluator.evaluated_reports_coverage["module-a"]
+    ev = evaluator.evaluated_reports_coverage["report.xml"]
     diff_o, _ = pr_comment_generator._calculate_baseline_report_diffs(ev)
     assert abs(diff_o - 20.0) < 0.1
 

--- a/tests/unit/test_jacoco_report.py
+++ b/tests/unit/test_jacoco_report.py
@@ -2661,7 +2661,7 @@ def test_exclude_paths_forwarded_to_scan_jacoco_xml_files(jacoco_report, mocker,
 
 def test_excluded_files_absent_from_evaluated_reports(jacoco_report, mocker, make_report_file_coverage):
     """Files excluded by exclude_paths are not present in the evaluation output."""
-    included_report = make_report_file_coverage(name="included-mod")
+    included_report = make_report_file_coverage(path="included.xml", name="included-mod")
 
     _patch_jr_run_inputs(mocker, exclude_paths=["**/excluded.xml"])
     mocker.patch("jacoco_report.jacoco_report.JaCoCoReport.scan_jacoco_xml_files", return_value=["included.xml"])
@@ -2671,5 +2671,7 @@ def test_excluded_files_absent_from_evaluated_reports(jacoco_report, mocker, mak
     jacoco_report.run()
 
     reports_data = json.loads(jacoco_report.evaluated_coverage_reports)
-    assert "included-mod" in reports_data
-    assert "excluded-mod" not in reports_data
+    # Reports are now keyed by file path; confirm the included report is present and excluded is not.
+    assert "included.xml" in reports_data
+    assert reports_data["included.xml"]["name"] == "included-mod"
+    assert not any(v.get("name") == "excluded-mod" for v in reports_data.values())

--- a/tests/unit/test_skip_unchanged.py
+++ b/tests/unit/test_skip_unchanged.py
@@ -77,11 +77,11 @@ def _make_run_mocks(
 def _report_with_changes(name: str, make_report_file_coverage) -> ReportFileCoverage:
     fc = FileCoverage("Foo.java", "src", Counter(0, 10), Counter(0, 10), Counter(0, 10),
                       Counter(0, 10), Counter(0, 10), Counter(0, 10))
-    return make_report_file_coverage(name=name, changed_files_coverage={"src/Foo.java": fc})
+    return make_report_file_coverage(path=f"{name}.xml", name=name, changed_files_coverage={"src/Foo.java": fc})
 
 
 def _report_without_changes(name: str, make_report_file_coverage) -> ReportFileCoverage:
-    return make_report_file_coverage(name=name, changed_files_coverage={})
+    return make_report_file_coverage(path=f"{name}.xml", name=name, changed_files_coverage={})
 
 
 # --- scan-stage filter tests ---
@@ -321,11 +321,13 @@ def test_skip_unchanged_evaluate_unchanged_true_mixed_input_uses_all_reports_for
     make_coverage,
 ):
     unchanged_low = make_report_file_coverage(
+        path="unchanged-low.xml",
         name="Unchanged Low",
         overall_coverage=make_coverage(instruction=Counter(missed=10, covered=0)),
         changed_files_coverage={},
     )
     changed_high = make_report_file_coverage(
+        path="changed-high.xml",
         name="Changed High",
         overall_coverage=make_coverage(instruction=Counter(missed=0, covered=10)),
         changed_files_coverage={


### PR DESCRIPTION
## Summary

- **Bug**: When all JaCoCo XML reports share the same `<report name="...">` (the Maven default `"JaCoCo Coverage Report"`), the action internally keyed every report by that name. Each newly processed report silently overwrote the previous one, leaving only the last group's data in the evaluation map. Per-group sections therefore never appeared in the PR comment and per-group threshold violations were evaluated against the wrong data.
- **Fix**: Change the `evaluated_reports_coverage` dictionary key from the XML report name to the file path (always unique). The display name is preserved in `EvaluatedReportCoverage.name` for all user-facing output (PR comment rows, violation messages). Baseline matching is updated to try path-based lookup first and fall back to name-based matching for setups where current and baseline reports live in different directory trees.
- **New test**: `test_duplicate_report_name_does_not_lose_data` — asserts that two reports sharing an XML name but different paths are both retained in the evaluation map (direct regression guard for this bug).

## Root cause

`CoverageEvaluator.evaluate()` stored each processed report as:

```python
self.evaluated_reports_coverage[report.name] = ...
```

`report.name` comes from the XML `<report name="...">` attribute. Maven's JaCoCo plugin defaults this attribute to `"JaCoCo Coverage Report"` for every module unless overridden. In a multi-module project with, say, 40 modules, every report lands on the same key and each one overwrites the previous. After the loop only one entry survives — the last report processed — so:

- Per-group PR comment sections have nothing to render (only the global aggregation row, which is tracked separately, survives).
- Per-group threshold violations are evaluated against the last surviving report's data, not the intended group's data.
- The duplicate-name `WARNING` log is emitted for every collision but the overwrite still happens.

## Changes

| File | What changed |
|---|---|
| `jacoco_report/model/evaluated_report_coverage.py` | Added `path: str` field; propagated through `to_dict()` and `clone()`. |
| `jacoco_report/evaluator/coverage_evaluator.py` | Key `evaluated_reports_coverage` by `report.path`; set `evaluated_coverage_report.path`; duplicate detection now tracks seen XML names (warning preserved, data loss eliminated); violation messages use `evaluated_coverage_report.name` (display name) instead of the dict key. |
| `jacoco_report/jacoco_report.py` | `skip_report_names` and `fail_unchanged` name sets now use `r.path` to match the new key. |
| `jacoco_report/generator/pr_comment_generator.py` | Added `_find_baseline_report()` with path-first / name-fallback matching strategy. Refactored `_compute_matched_global_diffs`, `calculate_baseline_group_diffs`, `_calculate_baseline_report_diffs`, and `generate_changed_files_table_with_baseline` to use this helper. `_sorted_report_keys` now sorts by display name (`EvaluatedReportCoverage.name`), not by path key, preserving alphabetical report ordering in the PR comment. |
| `tests/unit/evaluator/test_coverage_evaluator.py` | Updated 9 key lookups from `"report-x"` → `"report-x.xml"` to match path-keyed dict; updated violation message assertions to use display names; updated `test_duplicate_report_name_emits_warning` to use two distinct paths (tests the actual fix scenario); added `test_duplicate_report_name_does_not_lose_data`. |
| `tests/unit/generator/test_pr_comment_generator.py` | One `evaluate()`-sourced key lookup updated from `"module-a"` → `"report.xml"`. |
| `tests/unit/test_jacoco_report.py` | `test_excluded_files_absent_from_evaluated_reports` updated: fixture now uses an explicit path; assertions check the path key and verify `name` in the value. |
| `tests/unit/test_skip_unchanged.py` | `_report_with_changes` / `_report_without_changes` helpers now derive a unique path from the report name; inline fixtures in the mixed-input test also given unique paths. |

## Baseline matching behaviour after the fix

| Scenario | Matching strategy used | Result |
|---|---|---|
| Current and baseline built from the same directory tree (typical CI) | **Path-based** — identical relative paths intersect directly | Correct per-report and per-group deltas |
| Current and baseline in different directory trees, unique XML names (test fixtures, some CI setups) | **Name-based fallback** — XML name used when no path intersection found | Correct per-report and per-group deltas |
| All XML names identical AND different directory trees (degenerate case) | Neither strategy gives a reliable per-report match | Baseline deltas are 0 / imprecise — the primary fix (no data loss within the evaluator) still applies; users should set unique `<title>` per module via the Maven JaCoCo plugin |

## How to set unique report titles (recommended follow-up for users)

Add to each module's `pom.xml`:

```xml
<plugin>
  <groupId>org.jacoco</groupId>
  <artifactId>jacoco-maven-plugin</artifactId>
  <configuration>
    <title>${project.artifactId}</title>
  </configuration>
</plugin>
```

This gives each `jacoco.xml` a unique `<report name="...">` value (e.g. `bootstrap`, `data-access-api`), making per-module baseline deltas fully reliable.

Release Notes:
- **Fixed report name collision when multiple JaCoCo XML reports share the same `<title>`** — reports are now keyed by file path instead of name, so no data is silently overwritten when duplicate names exist.
- **Improved baseline diff matching** — global, group, and per-report diffs now use path-first matching with a name-based fallback, enabling correct delta computation when current and baseline reports live in different directory trees.
- **Report rows in PR comment now sorted by display name** — when no group order is configured, reports are sorted alphabetically by their display name rather than their internal path key.
- **Violation messages show report display name** — `Report '...'` in threshold-failure log messages now uses the human-readable name instead of the file path.