### PR TITLE
fix: correct `global-thresholds` Quick Start example to use 2-value format

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jobs:
             **/jacoco.xml
             **/reports/**/*.xml
             ${{ github.workspace }}/**/jacoco.xml
-          global-thresholds: '80*70*60'       # overall * changed-avg * per-changed-file
+          global-thresholds: '80*70'           # overall * changed-files-average
 
 ```
 


### PR DESCRIPTION
The Quick Start example in README.md showed `global-thresholds: '80*70*60'` with a
third `per-changed-file` component that `global-thresholds` does not accept.
The action validates exactly two `*`-separated values and rejects three with an error.

The third value (`per-changed-file`) belongs to `report-thresholds-default`, not
`global-thresholds`. All other occurrences across docs, examples, and tests were
already correct — only the Quick Start example was wrong.

**Change:** `'80*70*60'  # overall * changed-avg * per-changed-file`
→ `'80*70'  # overall * changed-files-average`

Release notes:

- **fix(docs):** corrected `global-thresholds` Quick Start example in README from
  the invalid 3-value format `'80*70*60'` to the correct 2-value format `'80*70'`
  (`overall*changed-files-average`). The third value was silently ignored at runtime
  but would cause a validation error in strict mode.
