### PR TITLE
PR: Fix Overall Coverage Calculation to Include All Reports

### DIFF
--- a/jacoco_report/jacoco_report.py
+++ b/jacoco_report/jacoco_report.py
@@ -310,11 +310,10 @@ class JaCoCoReport:
         # evaluate the coverage
         logger.info("Evaluating the coverage of the reports.")
         report_thresholds_default = ActionInputs.get_report_thresholds_default()
-        reports_for_evaluation = (
-            report_files_coverage + filtered_unchanged_reports
-            if skip_unchanged and evaluate_filtered_unchanged and filtered_unchanged_reports
-            else report_files_coverage
-        )
+        # Always include all reports for overall coverage calculation.
+        # The skip_unchanged filter should only affect comment rows and changed-files evaluation,
+        # not the overall coverage which must aggregate all reports regardless of changes.
+        reports_for_evaluation = report_files_coverage + filtered_unchanged_reports
         evaluator_for_results: CoverageEvaluator = CoverageEvaluator(
             report_files_coverage=reports_for_evaluation,
             global_min_coverage_overall=ActionInputs.get_global_overall_threshold(),
@@ -365,9 +364,12 @@ class JaCoCoReport:
 
         # generate the comment(s)
         logger.info("Generating PR comment(s).")
+        # Always skip display of filtered unchanged reports when skip_unchanged is enabled,
+        # regardless of evaluate_filtered_unchanged setting. These reports are included in
+        # overall coverage but should not appear as rows in the comment.
         skip_report_names: frozenset[str] = (
             frozenset(r.path for r in filtered_unchanged_reports)
-            if skip_unchanged and evaluate_filtered_unchanged and filtered_unchanged_reports
+            if skip_unchanged and filtered_unchanged_reports
             else frozenset()
         )
         generator = PRCommentGenerator(

--- a/tests/integration/test_matrix_skip_unchanged_comment_level.py
+++ b/tests/integration/test_matrix_skip_unchanged_comment_level.py
@@ -182,15 +182,18 @@ def test_skip_unchanged_true_all_comment_levels(
 
 
 def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture) -> None:
-    """Global coverage summary differs between skip-unchanged=false and skip-unchanged=true.
+    """Global coverage summary is identical between skip-unchanged=false and skip-unchanged=true.
 
-    With skip-unchanged=false all reports contribute to the global totals.
-    With skip-unchanged=true + evaluate-unchanged=false only the changed report contributes.
+    The overall coverage must ALWAYS include all reports regardless of skip-unchanged setting.
+    skip-unchanged should only filter comment rows and changed-files evaluation, not overall coverage.
 
-    The minimal-level comment bodies must differ, proving the filter runs before the
-    CoverageEvaluator rather than inside the comment generator.
+    With skip-unchanged=false all reports appear in rows.
+    With skip-unchanged=true + evaluate-unchanged=false only the changed report appears in rows,
+    but the global overall coverage still includes all reports.
+
+    The comment bodies may differ due to row filtering, but overall coverage must be identical.
     """
-    # Run 1: no filter — all reports in evaluator.
+    # Run 1: no filter — all reports in comment rows.
     captured_all = mock_github_offline(mocker, _CHANGED_FILES)
     r1 = capture_run(
         make_env_base(
@@ -202,7 +205,7 @@ def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture)
     assert r1.exit_code == 0, f"Run 1 failed: {r1.stdout}"
     assert len(captured_all) == 1, f"Expected one comment in run 1, got {len(captured_all)}"
 
-    # Run 2: scan-stage filter active — only module_large in evaluator.
+    # Run 2: scan-stage filter active — only module_large in rows, but all reports in overall coverage.
     captured_filtered = mock_github_offline(mocker, _CHANGED_FILES)
     r2 = capture_run(
         make_env_base(
@@ -222,17 +225,21 @@ def test_filter_before_evaluation_changes_global_coverage(mocker: MockerFixture)
         "Run 1 uses skip-unchanged=false; no report should be scan-stage filtered."
     )
     assert expected_filter_log in r2.stdout, (
-        "Run 2 must log that the unchanged report was filtered before evaluation."
+        "Run 2 must log that the unchanged report was filtered from comment rows."
     )
 
     overall_all = _extract_overall_coverage(captured_all[0])
     overall_filtered = _extract_overall_coverage(captured_filtered[0])
-    assert overall_all != overall_filtered, (
-        "Global Overall coverage must change when unchanged reports are excluded from evaluator input."
+    assert overall_all == overall_filtered, (
+        "Global Overall coverage must be identical in both runs "
+        "(both must include all reports regardless of skip-unchanged). "
+        f"Run 1 (skip=false): {overall_all}%, Run 2 (skip=true): {overall_filtered}%"
     )
 
-    assert captured_all[0] != captured_filtered[0], (
-        "Global coverage summary must differ between skip-unchanged=false (all reports evaluated) "
-        "and skip-unchanged=true (only the changed report evaluated). "
-        "Matching bodies would indicate the filter is not running before the evaluator."
+    # Comment bodies may differ due to row filtering, but the overall summary line must be identical
+    assert "| **Overall**" in captured_all[0], (
+        "Run 1 must include Overall coverage summary line"
+    )
+    assert "| **Overall**" in captured_filtered[0], (
+        "Run 2 must include Overall coverage summary line"
     )

--- a/tests/unit/test_skip_unchanged.py
+++ b/tests/unit/test_skip_unchanged.py
@@ -690,6 +690,99 @@ def test_skip_unchanged_with_report_groups_filters_groupless_unchanged_report(
     assert jr.violations == []
 
 
+def test_skip_unchanged_with_multiple_groups_overall_coverage_includes_all_reports(
+    mocker: MockerFixture, make_report_file_coverage, make_file_coverage, make_coverage
+):
+    """Bug test: overall coverage should include all reports regardless of changes.
+    
+    Setup:
+    - 4 reports (simulating 4 report groups)
+    - Only 1 report has changed files in PR
+    - skip_unchanged=true, evaluate_unchanged=false
+    
+    Expected:
+    - Overall coverage calculated from ALL 4 reports (not just the 1 with changes)
+    - Changed-files coverage only from reports with changes
+    
+    This tests the fix for the bug where overall coverage was calculated
+    only from reports with changed files when skip_unchanged was enabled.
+    """
+    from jacoco_report.model.report_group import ReportGroup
+    
+    # Create 4 reports with different overall coverage values
+    # Report with changes: 80% coverage
+    report_with_changes = make_report_file_coverage(
+        path="report1.xml",
+        name="Report 1 (Changed)",
+        overall_coverage=make_coverage(instruction=Counter(missed=20, covered=80)),
+        changed_files_coverage={"src/Foo.java": make_file_coverage(instruction=Counter(missed=20, covered=80))},
+        group_name="group-1"
+    )
+    
+    # 3 reports without changes: 90%, 70%, 60% coverage respectively
+    report_unchanged_2 = make_report_file_coverage(
+        path="report2.xml",
+        name="Report 2 (Unchanged)",
+        overall_coverage=make_coverage(instruction=Counter(missed=10, covered=90)),
+        changed_files_coverage={},
+        group_name="group-2"
+    )
+    
+    report_unchanged_3 = make_report_file_coverage(
+        path="report3.xml",
+        name="Report 3 (Unchanged)",
+        overall_coverage=make_coverage(instruction=Counter(missed=30, covered=70)),
+        changed_files_coverage={},
+        group_name="group-3"
+    )
+    
+    report_unchanged_4 = make_report_file_coverage(
+        path="report4.xml",
+        name="Report 4 (Unchanged)",
+        overall_coverage=make_coverage(instruction=Counter(missed=40, covered=60)),
+        changed_files_coverage={},
+        group_name="group-4"
+    )
+    
+    reports = [
+        report_with_changes,
+        report_unchanged_2,
+        report_unchanged_3,
+        report_unchanged_4,
+    ]
+    
+    # Create 4 report groups
+    groups = [
+        ReportGroup(name="group-1", paths=["report1.xml"]),
+        ReportGroup(name="group-2", paths=["report2.xml"]),
+        ReportGroup(name="group-3", paths=["report3.xml"]),
+        ReportGroup(name="group-4", paths=["report4.xml"]),
+    ]
+    
+    mocks = _make_run_mocks(
+        mocker,
+        skip_unchanged=True,
+        evaluate_unchanged=False,
+        reports=reports
+    )
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_report_groups", return_value=groups)
+    
+    jr = JaCoCoReport()
+    jr.run()
+    
+    # Overall coverage should be: (80 + 90 + 70 + 60) / (100 + 100 + 100 + 100) = 300 / 400 = 75%
+    expected_overall = 75.0
+    
+    # When skip_unchanged=true without evaluate_unchanged, 
+    # the bug is that overall coverage is calculated from ONLY the report with changes (80%)
+    # But it SHOULD include all reports (75%)
+    assert jr.total_overall_coverage == expected_overall, (
+        f"Overall coverage must include all 4 reports (expected {expected_overall}%), "
+        f"not just the report with changes (80%). "
+        f"Got: {jr.total_overall_coverage}%"
+    )
+
+
 def test_fail_on_threshold_list_form_no_warning(mocker: MockerFixture, caplog):
     mocker.patch("jacoco_report.action_inputs.get_action_input", return_value="overall")
     with caplog.at_level(logging.WARNING, logger="jacoco_report.action_inputs"):


### PR DESCRIPTION
## Summary
Fixes overall coverage calculation to include all reports regardless of whether changes are present in the PR. The `skip-unchanged` filter now only affects comment row display and changed-files threshold evaluation, not the overall coverage aggregation.

## Changes

### Core Fix
**File**: `jacoco_report/jacoco_report.py`

1. **Lines 313-320**: Always include all reports in overall coverage evaluation
   - Changed: `reports_for_evaluation = report_files_coverage + filtered_unchanged_reports` (unconditional)
   - Previously: Only included filtered reports if `evaluate_filtered_unchanged=true`

2. **Lines 369-377**: Fixed skip_report_names logic to exclude unchanged reports from comment rows
   - Changed: Filters unchanged reports from rows whenever `skip_unchanged=true`
   - Added comment explaining the separation: comment-row filtering vs. overall-coverage aggregation

### Test Coverage

**New Test**: `tests/unit/test_skip_unchanged.py`
- Added: `test_skip_unchanged_with_multiple_groups_overall_coverage_includes_all_reports`
- Verifies that with 4 reports (80%, 90%, 70%, 60% coverage), overall is correctly 75% not 80%

**Updated Test**: `tests/integration/test_matrix_skip_unchanged_comment_level.py`
- Updated: `test_filter_before_evaluation_changes_global_coverage`
- Changed expectation: overall coverage now identical in both skip=true/false runs
- Comment rows differ but overall value reflects all reports

## Behavior Change

### Before
- With `skip-unchanged=true` and `evaluate-unchanged=false`: unchanged reports excluded from overall coverage
- Overall coverage calculated from weight values (missed/covered counts) of changed reports only
- Example: 4 reports (80%/20m, 90%/10m, 70%/30m, 60%/40m) → only Report 1 included → 80/100 = 80%

### After
- With `skip-unchanged=true` and `evaluate-unchanged=false`: all reports included in overall coverage
- Overall coverage calculated from aggregated weight values (missed/covered counts) of all reports
- Example: 4 reports (80%/20m, 90%/10m, 70%/30m, 60%/40m) → all included → (80+90+70+60)/(100+100+100+100) = 75%
- Comment rows still exclude unchanged reports (as intended)

**Note**: Coverage is always calculated from weight values (missed/covered counts), not by averaging percentages. This ensures accurate aggregation proportional to each report's size.

## Migration Notes
No breaking changes. This is a bug fix that corrects incorrect behavior. Users who were relying on the buggy behavior (only counting changed reports in overall) will now see corrected overall coverage values.

Closes #201 

Release Notes:

- Fixed overall coverage calculation when using multiple report groups with skip-unchanged
- Overall coverage now includes all reports, not just reports with PR changes
- Example: 4 reports (80%, 90%, 70%, 60%) → Overall = 75% (was 80%)
- Unchanged reports hidden from comment rows but counted in overall metrics
- Applies to projects using skip-unchanged with multiple report groups
- Single report groups unaffected
- All tests passing with maintained coverage
