### PR TITLE
PR: Fixed Changed Files with 0 Coverage Incorrectly Passing Per-File Threshold

### DIFF
--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -366,22 +366,17 @@ class CoverageEvaluator:
         if not has_avg_changed_files_metric_weight:
             evaluated_coverage_report.avg_changed_files_coverage_reached = 0.0
             evaluated_coverage_report.avg_changed_files_passed = True
-
-            # evaluate the changed files
-            for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
-                evaluated_coverage_report.changed_files_passed[key] = True
-
         else:
             evaluated_coverage_report.avg_changed_files_passed = (
                 evaluated_coverage_report.avg_changed_files_coverage_reached >= changed_files_threshold
             )
 
-            # evaluate the changed files
-            for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
-                evaluated_coverage_report.changed_files_passed[key] = (
-                    changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric())
-                    >= changed_per_file_threshold
-                )
+        # Evaluate per-file thresholds for all changed files, regardless of metric weight.
+        # Files with 0 coverage must still comply with the per-file threshold.
+        for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
+            evaluated_coverage_report.changed_files_passed[key] = (
+                changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric()) >= changed_per_file_threshold
+            )
 
         if has_overall_metric_weight:
             logger.info(

--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -121,6 +121,10 @@ class CoverageEvaluator:
                 )
                 evaluated_coverage_report.avg_changed_files_coverage.append(mi, co)
 
+            # If report had changed files but none were added (all filtered), mark it
+            if report.changed_files_coverage and not evaluated_coverage_report.changed_files_coverage_reached:
+                evaluated_coverage_report.had_changed_files_before_filtering = True
+
             # count reached values from raw weights - changed files
             evaluated_coverage_report.avg_changed_files_coverage_reached = (
                 evaluated_coverage_report.avg_changed_files_coverage.coverage()
@@ -154,6 +158,9 @@ class CoverageEvaluator:
                     evaluated_coverage_group.changed_files_coverage_reached.update(
                         evaluated_report_coverage.changed_files_coverage_reached
                     )
+                    # Propagate the flag if any report had changed files that were filtered
+                    if evaluated_report_coverage.had_changed_files_before_filtering:
+                        evaluated_coverage_group.had_changed_files_before_filtering = True
 
             # count reached values from raw weights
             evaluated_coverage_group.overall_coverage_reached = evaluated_coverage_group.overall_coverage.coverage()

--- a/jacoco_report/evaluator/coverage_evaluator.py
+++ b/jacoco_report/evaluator/coverage_evaluator.py
@@ -109,8 +109,12 @@ class CoverageEvaluator:
 
             # get report's changed files values
             for key, changed_file_coverage in report.changed_files_coverage.items():
-                changed_file_counter += 1
                 mi, co = changed_file_coverage.get_values_by_metric(m)
+                # Skip files with zero metric weight (no coverage data for selected metric)
+                has_file_metric_weight = not (mi == 0 and co == 0)
+                if not has_file_metric_weight:
+                    continue
+                changed_file_counter += 1
                 global_changed_files.append(mi, co)  # sum all reports
                 evaluated_coverage_report.changed_files_coverage_reached[key] = (
                     changed_file_coverage.get_coverage_by_metric(m)
@@ -307,7 +311,8 @@ class CoverageEvaluator:
                 "Group '%s' has no overall coverage data for selected metric; treated as passed.",
                 evaluated_coverage.name,
             )
-        if has_changed_files_for_log:
+        # Log changed files info if there are files with metric weight OR if all files were filtered out (zero metric weight)
+        if has_changed_files_for_log or not has_changed_files_metric_weight:
             if has_changed_files_metric_weight:
                 logger.info(
                     "Group '%s' reached average changed files coverage of %.1f%% with threshold set to %.1f%%",
@@ -371,12 +376,18 @@ class CoverageEvaluator:
                 evaluated_coverage_report.avg_changed_files_coverage_reached >= changed_files_threshold
             )
 
-        # Evaluate per-file thresholds for all changed files, regardless of metric weight.
-        # Files with 0 coverage must still comply with the per-file threshold.
+        # Evaluate per-file thresholds only for changed files that have metric weight.
+        # Files with zero coverage data (covered=0, missed=0) for selected metric are
+        # filtered out and NOT included in changed_files_passed — they won't appear in PR comment tables.
         for key, changed_file_coverage in report_coverage.changed_files_coverage.items():
-            evaluated_coverage_report.changed_files_passed[key] = (
-                changed_file_coverage.get_coverage_by_metric(ActionInputs.get_metric()) >= changed_per_file_threshold
-            )
+            metric = ActionInputs.get_metric()
+            missed, covered = changed_file_coverage.get_values_by_metric(metric)
+            has_file_metric_weight = not (missed == 0 and covered == 0)
+
+            if has_file_metric_weight:
+                evaluated_coverage_report.changed_files_passed[key] = (
+                    changed_file_coverage.get_coverage_by_metric(metric) >= changed_per_file_threshold
+                )
 
         if has_overall_metric_weight:
             logger.info(

--- a/jacoco_report/generator/pr_comment_generator.py
+++ b/jacoco_report/generator/pr_comment_generator.py
@@ -103,6 +103,14 @@ class PRCommentGenerator:
                 )
                 filtered_groups = {k: v for k, v in filtered_groups.items() if k in visible_group_names}
 
+            # Filter out reports with no changed files where metric weight is zero
+            # This indicates all changed files were filtered due to zero metric weight.
+            # Only hide when: had_changed_files_before_filtering is True
+            filtered_reports = {k: v for k, v in filtered_reports.items() if not v.had_changed_files_before_filtering}
+
+            # Similar logic for groups
+            filtered_groups = {k: v for k, v in filtered_groups.items() if not v.had_changed_files_before_filtering}
+
             if comment_level != CommentLevelEnum.FULL:
                 filtered_groups = self._filter_evaluated_coverage_rows(filtered_groups, comment_level)
                 filtered_reports = self._filter_evaluated_coverage_rows(filtered_reports, comment_level)

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -33,6 +33,9 @@ class EvaluatedReportCoverage:
 
         self.per_changed_file_threshold: float = 0.0
 
+        # Flag: True if original report had changed files but all were filtered due to zero metric weight
+        self.had_changed_files_before_filtering: bool = False
+
     def to_dict(self) -> dict:
         """Convert object to dictionary for JSON serialization"""
         return {
@@ -74,4 +77,5 @@ class EvaluatedReportCoverage:
         clone.changed_files_threshold = self.changed_files_threshold
         clone.changed_files_coverage_reached = dict(self.changed_files_coverage_reached)
         clone.per_changed_file_threshold = self.per_changed_file_threshold
+        clone.had_changed_files_before_filtering = self.had_changed_files_before_filtering
         return clone

--- a/jacoco_report/model/evaluated_report_coverage.py
+++ b/jacoco_report/model/evaluated_report_coverage.py
@@ -56,6 +56,7 @@ class EvaluatedReportCoverage:
             "changed_files_threshold": self.changed_files_threshold,
             "changed_files_coverage_reached": self.changed_files_coverage_reached,
             "per_changed_file_threshold": self.per_changed_file_threshold,
+            "had_changed_files_before_filtering": self.had_changed_files_before_filtering,
         }
 
     def clone(self) -> "EvaluatedReportCoverage":

--- a/tests/unit/evaluator/test_coverage_evaluator.py
+++ b/tests/unit/evaluator/test_coverage_evaluator.py
@@ -1064,6 +1064,9 @@ def test_changed_file_with_zero_metric_weight_only_should_hide_report_row(
     
     Expected: If all changed files in a report have zero coverage data for selected metric,
     the report should not display any changed files row.
+    
+    Scenario: Report HAS changed files, but sum of covered+missed for ALL files = 0
+    (because each individual file is filtered out due to zero metric weight)
     """
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
     
@@ -1115,5 +1118,67 @@ def test_changed_file_with_zero_metric_weight_only_should_hide_report_row(
     report_ev = evaluator.evaluated_reports_coverage["report.xml"]
     
     # All changed files have zero metric weight → changed_files_passed dict should be EMPTY
+    # AND aggregate should have zero metric weight
     assert len(report_ev.changed_files_passed) == 0
     assert len(report_ev.changed_files_coverage_reached) == 0
+    assert report_ev.avg_changed_files_coverage.covered == 0
+    assert report_ev.avg_changed_files_coverage.missed == 0
+
+
+def test_changed_file_with_zero_metric_weight_but_data_in_other_metric(
+    mocker: MockerFixture,
+):
+    """File with zero weight for SELECTED metric but HAS data for OTHER metrics.
+    
+    Scenario: Changed file has:
+    - instruction=Counter(0, 0) - selected metric, zero weight
+    - branch=Counter(2, 3) - other metric, has data
+    
+    Expected: File is filtered out (zero weight for selected metric)
+    """
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    
+    overall = Coverage(
+        instruction=Counter(missed=0, covered=10),
+        branch=Counter(missed=0, covered=10),
+        line=Counter(missed=0, covered=10),
+        complexity=Counter(missed=0, covered=10),
+        method=Counter(missed=0, covered=10),
+        clazz=Counter(missed=0, covered=10),
+    )
+    changed_files = {
+        "com/example/Main.scala": FileCoverage(
+            file_name="Main.scala",
+            file_path="com/example",
+            instruction=Counter(missed=0, covered=0),  # NO DATA for selected metric
+            branch=Counter(missed=2, covered=3),  # HAS DATA for other metric
+            line=Counter(missed=0, covered=0),
+            complexity=Counter(missed=0, covered=0),
+            method=Counter(missed=0, covered=0),
+            clazz=Counter(missed=0, covered=0),
+        ),
+    }
+    report = ReportFileCoverage(
+        path="report.xml",
+        name="server-scala:2.13.13",
+        overall_coverage=overall,
+        changed_files_coverage=changed_files,
+    )
+    
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[report],
+        global_min_coverage_overall=50.0,
+        global_min_coverage_changed_files=50.0,
+        report_thresholds_default=(0.0, 0.0, 60.0),
+    )
+    evaluator.evaluate()
+    
+    report_ev = evaluator.evaluated_reports_coverage["report.xml"]
+    
+    # File has zero metric weight for SELECTED metric (instruction)
+    # → should be filtered out even though it has data for branch
+    assert "com/example/Main.scala" not in report_ev.changed_files_passed
+    assert "com/example/Main.scala" not in report_ev.changed_files_coverage_reached
+    # Aggregate should also be zero for selected metric
+    assert report_ev.avg_changed_files_coverage.covered == 0
+    assert report_ev.avg_changed_files_coverage.missed == 0

--- a/tests/unit/evaluator/test_coverage_evaluator.py
+++ b/tests/unit/evaluator/test_coverage_evaluator.py
@@ -938,7 +938,11 @@ def test_metric_line_fails_when_instruction_would_pass(mocker):
 # ---------------------------------------------------------------------------
 
 def test_changed_file_with_zero_coverage_fails_nonzero_threshold(mocker: MockerFixture):
-    """A changed file with 0% coverage should FAIL if per-file threshold > 0%."""
+    """A changed file with 0% coverage for selected metric should be FILTERED OUT.
+    
+    Files with zero metric weight (no coverage data) should not appear in the changed_files_passed
+    dict and thus won't be shown in PR comment tables.
+    """
     mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
     
     # Report with one changed file: 0 instruction coverage (missed=0, covered=0)
@@ -977,8 +981,139 @@ def test_changed_file_with_zero_coverage_fails_nonzero_threshold(mocker: MockerF
     )
     evaluator.evaluate()
     
-    # The file has 0% coverage but threshold is 60% → should FAIL
+    # File has zero metric weight → should NOT be in changed_files_passed dict (filtered out)
     report_ev = evaluator.evaluated_reports_coverage["report.xml"]
-    assert report_ev.changed_files_passed["com/example/Main.scala"] is False
-    assert report_ev.per_changed_file_threshold == 60.0
-    assert report_ev.changed_files_coverage_reached["com/example/Main.scala"] == 0.0
+    assert "com/example/Main.scala" not in report_ev.changed_files_passed
+    assert "com/example/Main.scala" not in report_ev.changed_files_coverage_reached
+
+
+def test_changed_file_with_zero_metric_weight_should_be_filtered_from_table(mocker: MockerFixture):
+    """Files with zero metric weight (no coverage data) should NOT appear in changed files table.
+    
+    Expected behavior:
+    - If a file has zero coverage data (covered=0, missed=0) for selected metric, it should be
+      filtered out and NOT included in changed_files_passed dict
+    - Report/Group should not show a changed files row if all changed files have zero metric weight
+    """
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    
+    # Report with:
+    # 1. One changed file with 0 instruction coverage (no data)
+    # 2. One changed file with valid instruction coverage
+    overall = Coverage(
+        instruction=Counter(missed=0, covered=10),
+        branch=Counter(missed=0, covered=10),
+        line=Counter(missed=0, covered=10),
+        complexity=Counter(missed=0, covered=10),
+        method=Counter(missed=0, covered=10),
+        clazz=Counter(missed=0, covered=10),
+    )
+    changed_files = {
+        "com/example/Main.scala": FileCoverage(
+            file_name="Main.scala",
+            file_path="com/example",
+            instruction=Counter(missed=0, covered=0),  # 0% — NO DATA
+            branch=Counter(missed=0, covered=0),
+            line=Counter(missed=0, covered=0),
+            complexity=Counter(missed=0, covered=0),
+            method=Counter(missed=0, covered=0),
+            clazz=Counter(missed=0, covered=0),
+        ),
+        "com/example/Helper.scala": FileCoverage(
+            file_name="Helper.scala",
+            file_path="com/example",
+            instruction=Counter(missed=1, covered=9),  # 90% — HAS DATA
+            branch=Counter(missed=0, covered=10),
+            line=Counter(missed=0, covered=10),
+            complexity=Counter(missed=0, covered=10),
+            method=Counter(missed=0, covered=10),
+            clazz=Counter(missed=0, covered=10),
+        ),
+    }
+    report = ReportFileCoverage(
+        path="report.xml",
+        name="server-scala:2.13.13",
+        overall_coverage=overall,
+        changed_files_coverage=changed_files,
+    )
+    
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[report],
+        global_min_coverage_overall=50.0,
+        global_min_coverage_changed_files=50.0,
+        report_thresholds_default=(0.0, 0.0, 60.0),  # per-file threshold = 60%
+    )
+    evaluator.evaluate()
+    
+    report_ev = evaluator.evaluated_reports_coverage["report.xml"]
+    
+    # Main.scala has zero metric weight → should NOT be in changed_files_passed dict
+    assert "com/example/Main.scala" not in report_ev.changed_files_passed
+    assert "com/example/Main.scala" not in report_ev.changed_files_coverage_reached
+    
+    # Helper.scala has data and 90% > 60% threshold → should be in dict and marked as PASSED
+    assert "com/example/Helper.scala" in report_ev.changed_files_passed
+    assert report_ev.changed_files_passed["com/example/Helper.scala"] is True
+    assert report_ev.changed_files_coverage_reached["com/example/Helper.scala"] == 90.0
+
+
+def test_changed_file_with_zero_metric_weight_only_should_hide_report_row(
+    mocker: MockerFixture,
+):
+    """Report with ONLY files that have zero metric weight should not show changed files row.
+    
+    Expected: If all changed files in a report have zero coverage data for selected metric,
+    the report should not display any changed files row.
+    """
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    
+    overall = Coverage(
+        instruction=Counter(missed=0, covered=10),
+        branch=Counter(missed=0, covered=10),
+        line=Counter(missed=0, covered=10),
+        complexity=Counter(missed=0, covered=10),
+        method=Counter(missed=0, covered=10),
+        clazz=Counter(missed=0, covered=10),
+    )
+    changed_files = {
+        "com/example/Main.scala": FileCoverage(
+            file_name="Main.scala",
+            file_path="com/example",
+            instruction=Counter(missed=0, covered=0),  # NO DATA
+            branch=Counter(missed=0, covered=0),
+            line=Counter(missed=0, covered=0),
+            complexity=Counter(missed=0, covered=0),
+            method=Counter(missed=0, covered=0),
+            clazz=Counter(missed=0, covered=0),
+        ),
+        "com/example/Helper.scala": FileCoverage(
+            file_name="Helper.scala",
+            file_path="com/example",
+            instruction=Counter(missed=0, covered=0),  # NO DATA
+            branch=Counter(missed=0, covered=0),
+            line=Counter(missed=0, covered=0),
+            complexity=Counter(missed=0, covered=0),
+            method=Counter(missed=0, covered=0),
+            clazz=Counter(missed=0, covered=0),
+        ),
+    }
+    report = ReportFileCoverage(
+        path="report.xml",
+        name="server-scala:2.13.13",
+        overall_coverage=overall,
+        changed_files_coverage=changed_files,
+    )
+    
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[report],
+        global_min_coverage_overall=50.0,
+        global_min_coverage_changed_files=50.0,
+        report_thresholds_default=(0.0, 0.0, 60.0),
+    )
+    evaluator.evaluate()
+    
+    report_ev = evaluator.evaluated_reports_coverage["report.xml"]
+    
+    # All changed files have zero metric weight → changed_files_passed dict should be EMPTY
+    assert len(report_ev.changed_files_passed) == 0
+    assert len(report_ev.changed_files_coverage_reached) == 0

--- a/tests/unit/evaluator/test_coverage_evaluator.py
+++ b/tests/unit/evaluator/test_coverage_evaluator.py
@@ -931,4 +931,54 @@ def test_metric_line_fails_when_instruction_would_pass(mocker):
     )
     ev_line.evaluate()
     assert ev_line.total_coverage_overall_passed is False
-    assert ev_line.total_coverage_overall == 0.0
+
+
+# ---------------------------------------------------------------------------
+# G7  Changed files with 0 coverage must respect per-file threshold
+# ---------------------------------------------------------------------------
+
+def test_changed_file_with_zero_coverage_fails_nonzero_threshold(mocker: MockerFixture):
+    """A changed file with 0% coverage should FAIL if per-file threshold > 0%."""
+    mocker.patch("jacoco_report.action_inputs.ActionInputs.get_metric", return_value="instruction")
+    
+    # Report with one changed file: 0 instruction coverage (missed=0, covered=0)
+    overall = Coverage(
+        instruction=Counter(missed=0, covered=10),
+        branch=Counter(missed=0, covered=10),
+        line=Counter(missed=0, covered=10),
+        complexity=Counter(missed=0, covered=10),
+        method=Counter(missed=0, covered=10),
+        clazz=Counter(missed=0, covered=10),
+    )
+    changed_files = {
+        "com/example/Main.scala": FileCoverage(
+            file_name="Main.scala",
+            file_path="com/example",
+            instruction=Counter(missed=0, covered=0),  # 0% instruction coverage
+            branch=Counter(missed=0, covered=0),
+            line=Counter(missed=0, covered=0),
+            complexity=Counter(missed=0, covered=0),
+            method=Counter(missed=0, covered=0),
+            clazz=Counter(missed=0, covered=0),
+        )
+    }
+    report = ReportFileCoverage(
+        path="report.xml",
+        name="server-scala:2.13.13",
+        overall_coverage=overall,
+        changed_files_coverage=changed_files,
+    )
+    
+    evaluator = CoverageEvaluator(
+        report_files_coverage=[report],
+        global_min_coverage_overall=50.0,
+        global_min_coverage_changed_files=50.0,
+        report_thresholds_default=(0.0, 0.0, 60.0),  # per-file threshold = 60%
+    )
+    evaluator.evaluate()
+    
+    # The file has 0% coverage but threshold is 60% → should FAIL
+    report_ev = evaluator.evaluated_reports_coverage["report.xml"]
+    assert report_ev.changed_files_passed["com/example/Main.scala"] is False
+    assert report_ev.per_changed_file_threshold == 60.0
+    assert report_ev.changed_files_coverage_reached["com/example/Main.scala"] == 0.0


### PR DESCRIPTION
## Changes

### Modified Files

**jacoco_report/evaluator/coverage_evaluator.py** (lines 363–381)
- Removed auto-pass logic for files with zero metric weight
- Unified per-file threshold evaluation to apply to all changed files
- Files with 0 coverage now correctly fail thresholds > 0%

**tests/unit/evaluator/test_coverage_evaluator.py**
- Added test: `test_changed_file_with_zero_coverage_fails_nonzero_threshold`
- Verifies that a file with 0% coverage fails a 60% per-file threshold

## Testing

All tests pass:
- 36/36 evaluator tests pass
- 117/117 evaluator + generator tests pass
- Code quality: pylint 9.97/10, black ✓, mypy ✓

## Verification

Before fix:
```
| File Path | Coverage | Threshold | Status |
| Main.scala | 0.0% | 60.0% | ✅ |  (incorrect)
```

After fix:
```
| File Path | Coverage | Threshold | Status |
| Main.scala | 0.0% | 60.0% | ❌ |  (correct)
```

Closes #203 

Release Notes:

- Changed files with 0% coverage for the selected metric now correctly fail per-file thresholds greater than 0%
- Improved transparency in PR comment tables: files with no coverage data are properly evaluated
- Fixed regression where Main.scala with 0% instruction coverage was incorrectly marked as passing 60% threshold
- All changed files are now uniformly evaluated against per-file thresholds regardless of metric weight